### PR TITLE
fix(ui): 避免工具诊断摘要被 trailing 按钮挤成竖排

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantToolsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantToolsPage.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.ui.pages.assistant.detail
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -39,6 +40,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.annotation.StringRes
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -951,14 +953,31 @@ private fun AssistantToolsContent(
         if (advancedExpanded) {
             CardGroup(title = { Text(stringResource(R.string.assistant_tools_diagnostics_title)) }) {
                 item(
-                    headlineContent = { Text(readableDiagnostics) },
-                    supportingContent = {
-                        if (problemCount > 0) {
-                            Text(stringResource(R.string.assistant_tools_diagnostics_problems_count, problemCount))
+                    headlineContent = {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                        ) {
+                            Text(
+                                text = readableDiagnostics,
+                                maxLines = 3,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            if (problemCount > 0) {
+                                Text(
+                                    stringResource(
+                                        R.string.assistant_tools_diagnostics_problems_count,
+                                        problemCount,
+                                    ),
+                                )
+                            }
                         }
                     },
-                    trailingContent = {
-                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    supportingContent = {
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
                             TextButton(onClick = { diagnosticsExpanded = !diagnosticsExpanded }) {
                                 Text(stringResource(R.string.assistant_tools_diagnostics_details))
                             }


### PR DESCRIPTION
## 关联任务 | Linked issue

无独立 Issue。用户在赋能工具页展开高级后，工具诊断卡片左侧摘要被右侧三按钮挤成竖排，直接按截图修布局。

## 变更说明 | Changes

`AssistantToolsPage` 高级区「工具诊断」卡原先把「详情 / 仅问题 / 复制安全摘要」放在 M3 `ListItem.trailingContent`。trailing 按固有宽度占位，中间 headline 可用宽度接近一字，`Text` softWrap 后变成逐字竖排（截图中「有效 18 / 共 … 个工具需要关注」）。

改动：
- `headlineContent`：可读摘要 + 问题数，全宽 `Column`，摘要 `maxLines=3` + `Ellipsis`
- `supportingContent`：三个操作按钮改为 `FlowRow`，窄屏可换行
- 去掉该 item 的 `trailingContent`
- 展开/仅问题/复制剪贴板逻辑不变

## 验收条件 | Acceptance criteria

- [ ] 展开「高级」后，诊断摘要横向可读，不再单字竖排
- [ ] 「详情」「仅问题」「复制安全摘要」仍可用；窄屏下按钮可折行
- [ ] 问题数文案在 `problemCount > 0` 时仍显示
- [ ] 复制内容仍为 `copySummary()` 安全摘要

## UI 截图 / 录屏 | UI evidence

问题态：摘要被 trailing 三按钮挤成竖排。  
布局预览（前后对比）：https://html.huhage.fun/share/xvuGScdlYe  
（预览为示意；实现基于当前高级区 `readableDiagnostics` 文案。）

## 测试 | Testing

- 命令 / 检查：本地 diff 审阅；环境无 Java/Gradle，未跑 assemble/测试
- 结果：未执行仪器/单元测试；需真机/模拟器打开赋能工具 → 展开高级 → 工具诊断卡目视确认

## 数据兼容 | Data compatibility

N/A（纯 UI 布局）

## 风险与回滚 | Risks and rollback

- 风险：supporting 区按钮变高，卡片略增高
- 回滚：revert 本提交即可

## 已知限制 | Known limitations

- 选择模式批量条等其它带 trailing 多按钮的 ListItem 未一并改动
- 无自动化 UI 测试覆盖该卡

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [ ] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」