### PR TITLE
feat(ci): 轻量 PR 试装 APK（独立 applicationId，不覆盖正式版）

### DIFF
--- a/.github/workflows/pr-apk.yml
+++ b/.github/workflows/pr-apk.yml
@@ -1,0 +1,109 @@
+# 轻量试装包：对任意分支 / commit 手动出 arm64 release APK。
+# 用法：Actions → PR / Branch APK → Run workflow → 可选填 ref（空则用所选 branch）
+# 产物：Artifacts，不覆盖 nightly、不 bump 版本、不发 Release。
+# 关联：Closes #167
+name: PR / Branch APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "分支名或 commit SHA（留空则用上方 Branch 选择）"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-apk-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve ref
+        id: ref
+        run: |
+          REF="${{ github.event.inputs.ref }}"
+          if [ -z "$REF" ]; then
+            REF="${{ github.ref_name }}"
+          fi
+          echo "value=$REF" >> "$GITHUB_OUTPUT"
+          echo "Building ref: $REF"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.value }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web-ui/pnpm-lock.yaml
+
+      - name: Install web-ui dependencies
+        working-directory: web-ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+      - name: Prepare signing
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::KEYSTORE_BASE64 secret is missing"
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > rikka-arsucar-release.jks
+          cat >> local.properties << EOF
+          storeFile=rikka-arsucar-release.jks
+          storePassword=${KEYSTORE_PASSWORD}
+          keyAlias=${KEY_ALIAS}
+          keyPassword=${KEY_PASSWORD}
+          EOF
+
+      - name: Assemble release
+        run: |
+          chmod +x gradlew
+          ./gradlew :app:assembleRelease --no-daemon
+
+      - name: Short SHA
+        id: meta
+        run: |
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "ref_slug=$(echo '${{ steps.ref.outputs.value }}' | tr '/:' '--' | tr -cd '[:alnum:]._-')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rikka-arsucar-${{ steps.meta.outputs.ref_slug }}-${{ steps.meta.outputs.sha }}-${{ github.run_id }}
+          path: app/build/outputs/apk/release/*arm64-v8a*release*.apk
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/pr-apk.yml
+++ b/.github/workflows/pr-apk.yml
@@ -1,6 +1,7 @@
-# 轻量试装包：对任意分支 / commit 手动出 arm64 release APK。
+# 轻量试装包：对任意分支 / commit 手动出 arm64 prTest APK。
 # 用法：Actions → PR / Branch APK → Run workflow → 可选填 ref（空则用所选 branch）
-# 产物：Artifacts，不覆盖 nightly、不 bump 版本、不发 Release。
+# 产物：Artifacts；applicationId = me.arsucar.rikka.pr，不覆盖正式版 me.arsucar.rikka。
+# 不覆盖 nightly、不 bump 版本、不发 Release。
 # 关联：Closes #167
 name: PR / Branch APK
 
@@ -89,10 +90,11 @@ jobs:
           keyPassword=${KEY_PASSWORD}
           EOF
 
-      - name: Assemble release
+      # prTest：applicationIdSuffix=.pr，与正式版并存，不会覆盖安装
+      - name: Assemble prTest
         run: |
           chmod +x gradlew
-          ./gradlew :app:assembleRelease --no-daemon
+          ./gradlew :app:assemblePrTest --no-daemon
 
       - name: Short SHA
         id: meta
@@ -103,7 +105,9 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: rikka-arsucar-${{ steps.meta.outputs.ref_slug }}-${{ steps.meta.outputs.sha }}-${{ github.run_id }}
-          path: app/build/outputs/apk/release/*arm64-v8a*release*.apk
+          name: rikka-arsucar-pr-${{ steps.meta.outputs.ref_slug }}-${{ steps.meta.outputs.sha }}-${{ github.run_id }}
+          path: |
+            app/build/outputs/apk/prTest/*arm64-v8a*prTest*.apk
+            app/build/outputs/apk/prTest/**/*arm64*.apk
           if-no-files-found: error
           retention-days: 14

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,29 @@ android {
             buildConfigField("String", "VERSION_CODE", "\"${android.defaultConfig.versionCode}\"")
             buildConfigField("String", "GITHUB_API_TOKEN", "\"${project.findProperty("github.api.token")?.toString() ?: ""}\"")
         }
+        // CI 试装包：独立 applicationId，可与正式版并存，不会覆盖安装 me.arsucar.rikka
+        create("prTest") {
+            initWith(getByName("release"))
+            applicationIdSuffix = ".pr"
+            versionNameSuffix = "-pr"
+            // 桌面显示名区分正式版（Manifest 用 @string/app_name）
+            resValue("string", "app_name", "RikkaRs PR")
+            buildConfigField(
+                "String",
+                "VERSION_NAME",
+                "\"${android.defaultConfig.versionName}-pr\"",
+            )
+            buildConfigField(
+                "String",
+                "VERSION_CODE",
+                "\"${android.defaultConfig.versionCode}\"",
+            )
+            buildConfigField(
+                "String",
+                "GITHUB_API_TOKEN",
+                "\"${project.findProperty("github.api.token")?.toString() ?: ""}\"",
+            )
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #167

## 变更说明 | Changes

1. **新增 buildType `prTest`**（`app/build.gradle.kts`）
   - `initWith(release)` + 签名/minify 与 release 一致
   - `applicationIdSuffix = ".pr"` → 包名 `me.arsucar.rikka.pr`
   - `versionNameSuffix = "-pr"`，桌面名 `RikkaRs PR`
   - **可与正式版 `me.arsucar.rikka` 并存，安装不会覆盖正式包**

2. **新增 workflow** `.github/workflows/pr-apk.yml`（Actions：`PR / Branch APK`）
   - 仅 `workflow_dispatch`，可选 `ref`
   - 任务：`./gradlew :app:assemblePrTest`
   - 产物：`upload-artifact`，保留 14 天
   - 不覆盖 `nightly`、不 bump 版本、不发 Release

## 验收条件 | Acceptance criteria

- [ ] Actions 中可手动 Run「PR / Branch APK」
- [ ] 产出 arm64 prTest APK，安装后桌面显示「RikkaRs PR」
- [ ] 安装试装包后，原正式版 RikkaRs 仍在、数据不被替换
- [ ] 不覆盖 `nightly` prerelease，不改 versionCode 正式发布逻辑

## UI 截图 / 录屏 | UI evidence

N/A（CI + buildType；真机可看桌面是否两个图标）

## 测试 | Testing

- 命令 / 检查：YAML 与 Gradle DSL 审阅；工作区无 Java/Gradle，未跑 assemble
- 结果：合并后请在 Actions 对任意分支触发一次，真机安装确认与正式版并存

## 数据兼容 | Data compatibility

试装包为独立 applicationId，**不共享**正式版应用数据（Android 沙箱隔离）。仅用于 UI/功能试装，不是正式版热修通道。

## 风险与回滚 | Risks and rollback

- 风险：多一个 buildType 略增配置面；误用 prTest 当正式发版
- 回滚：删 workflow + 删 prTest buildType

## 已知限制 | Known limitations

- 不在 PR 打开时自动构建（省 Actions 额度）
- artifact 需有仓库权限账号下载
- FileProvider 等 authority 随 applicationId 变化，试装包内分享路径与正式版隔离（预期行为）

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查提交内容，不含密钥等敏感信息
- [x] 用法写在 workflow 文件头；正式 CHANGELOG N/A
- [ ] 合并后将任务置为「待验证」；验收通过后再「已完成」