### PR TITLE
feat: stream AI reply drafts into the chat composer

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/prompts/Suggestion.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/prompts/Suggestion.kt
@@ -16,3 +16,21 @@ internal val DEFAULT_SUGGESTION_PROMPT = """
     {content}
     </content>
 """.trimIndent()
+
+
+internal val DEFAULT_INPUT_DRAFT_PROMPT = """
+    I will provide recent chat context in the `<content>` block, including messages between the User and the AI assistant.
+    Write one complete reply draft from the **User's** perspective.
+
+    Rules:
+    1. Output only the reply draft, without labels, commentary, alternatives, or surrounding quotes.
+    2. Use {locale} language.
+    3. Respond naturally to the latest assistant message and remain consistent with the context.
+    4. Imitate the user's previous conversational style where possible.
+    5. Do not invent personal facts, commitments, or preferences not supported by the context.
+    6. Act as the User, not the Assistant.
+
+    <content>
+    {content}
+    </content>
+""".trimIndent()

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
@@ -42,11 +43,13 @@ import me.rerere.ai.ui.canResumeToolExecution
 import me.rerere.ai.ui.finishPendingTools
 import me.rerere.ai.ui.finishReasoning
 import me.rerere.ai.ui.isEmptyInputMessage
+import me.rerere.ai.ui.handleMessageChunk
 
 import me.rerere.common.android.Logging
 import me.rerere.rikkahub.AppScope
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.ai.GenerationChunk
+import me.rerere.rikkahub.data.ai.prompts.DEFAULT_INPUT_DRAFT_PROMPT
 import me.rerere.rikkahub.data.ai.GenerationHandler
 import me.rerere.rikkahub.data.ai.ContextPreview
 import me.rerere.rikkahub.data.ai.GenerationPreparationMode
@@ -2084,6 +2087,46 @@ class ChatService(
         }.onFailure {
             it.printStackTrace()
         }
+    }
+
+    /** Streams a user-side reply draft without mutating or persisting the conversation. */
+    suspend fun generateInputDraft(
+        conversationId: Uuid,
+        conversation: Conversation,
+        onStreamUpdate: (String) -> Unit,
+    ): String {
+        require(conversation.id == conversationId) { "Conversation ID mismatch" }
+        require(conversation.currentMessages.isNotEmpty()) {
+            context.getString(R.string.input_draft_empty_conversation)
+        }
+        val settings = settingsStore.settingsFlow.first()
+        val model = settings.findModelById(
+            settings.suggestionModelId,
+            fallback = settings.fastModelId,
+        ) ?: error(context.getString(R.string.input_draft_model_unavailable))
+        val provider = model.findProvider(settings.providers)
+            ?: error(context.getString(R.string.input_draft_model_unavailable))
+        val providerHandler = providerManager.getProviderByType(provider)
+        val prompt = DEFAULT_INPUT_DRAFT_PROMPT.applyPlaceholders(
+            "locale" to Locale.getDefault().displayName,
+            "content" to conversation.currentMessages
+                .takeLast(8)
+                .joinToString("\n\n") { it.summaryAsText(maxLength = 500) },
+        )
+        var messages = listOf(UIMessage.user(prompt))
+        var draft = ""
+        val params = backgroundTextGenerationParams(model)
+        ProviderRateLimiter.await(provider = provider, messages = messages, params = params)
+        providerHandler.streamText(
+            providerSetting = provider,
+            messages = messages,
+            params = params,
+        ).collect { chunk ->
+            messages = messages.handleMessageChunk(chunk, model)
+            draft = messages.lastOrNull()?.toText()?.trimStart().orEmpty()
+            onStreamUpdate(draft)
+        }
+        return draft.trim()
     }
 
     // ---- 压缩对话历史 ----

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -69,6 +70,8 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
@@ -91,6 +94,7 @@ import me.rerere.hugeicons.stroke.ArrowUp02
 import me.rerere.hugeicons.stroke.Book02
 import me.rerere.hugeicons.stroke.Cancel01
 import me.rerere.hugeicons.stroke.FullScreen
+import me.rerere.hugeicons.stroke.MagicWand01
 import me.rerere.hugeicons.stroke.Zap
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.datastore.Settings
@@ -126,6 +130,8 @@ fun ChatInput(
     assistant: Assistant,
     hazeState: HazeState,
     enableSearch: Boolean,
+    inputDraftLoading: Boolean,
+    inputDraftEnabled: Boolean,
     onToggleSearch: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     completionProviders: List<ChatCompletionProvider> = emptyList(),
@@ -134,11 +140,14 @@ fun ChatInput(
     onUpdateAssistant: (Assistant) -> Unit,
     onUpdateSearchService: (Int) -> Unit,
     onMoreClick: () -> Unit,
+    onGenerateInputDraft: () -> Unit,
+    onCancelInputDraft: () -> Unit,
     onCancelClick: () -> Unit,
     onSendClick: () -> Unit,
     onLongSendClick: () -> Unit,
 ) {
     val toaster = LocalToaster.current
+    val inputDraftCancelDescription = stringResource(R.string.input_draft_cancel)
     val hazeTintColor = MaterialTheme.colorScheme.surfaceContainerLow
     val inputHazeStyle = HazeMaterials.thin(containerColor = hazeTintColor)
 
@@ -308,6 +317,27 @@ fun ChatInput(
                         }
 
                         ActionIconButton(
+                            onClick = if (inputDraftLoading) onCancelInputDraft else onGenerateInputDraft,
+                            enabled = inputDraftLoading || inputDraftEnabled,
+                        ) {
+                            if (inputDraftLoading) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier
+                                        .size(18.dp)
+                                        .semantics {
+                                            contentDescription = inputDraftCancelDescription
+                                        },
+                                    strokeWidth = 2.dp,
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = HugeIcons.MagicWand01,
+                                    contentDescription = stringResource(R.string.input_draft_generate),
+                                )
+                            }
+                        }
+
+                        ActionIconButton(
                             onClick = onMoreClick
                         ) {
                             Icon(
@@ -323,6 +353,7 @@ fun ChatInput(
                                     when (asrState.status) {
                                         ASRStatus.Listening -> asr.stop()
                                         ASRStatus.Idle, ASRStatus.Error -> {
+                                            if (inputDraftLoading) return@AsrButton
                                             if (!asrPermission.allRequiredPermissionsGranted) {
                                                 asrPermission.requestPermissions()
                                             } else {
@@ -405,10 +436,12 @@ fun ChatInput(
 @Composable
 private fun ActionIconButton(
     onClick: () -> Unit,
+    enabled: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     Surface(
         onClick = onClick,
+        enabled = enabled,
         modifier = Modifier.size(30.dp),
         shape = CircleShape,
         tonalElevation = 0.dp,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -136,6 +136,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
     val currentChatModel by vm.currentChatModel.collectAsStateWithLifecycle()
     val enableWebSearch by vm.enableWebSearch.collectAsStateWithLifecycle()
     val errors by vm.errors.collectAsStateWithLifecycle()
+    val inputDraftLoading by vm.inputDraftLoading.collectAsStateWithLifecycle()
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val softwareKeyboardController = LocalSoftwareKeyboardController.current
@@ -412,6 +413,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
                                 chatListState = chatListState,
                                 enableWebSearch = enableWebSearch,
                                 currentChatModel = currentChatModel,
+                                inputDraftLoading = inputDraftLoading,
                                 bigScreen = true,
                                 errors = errors,
                                 onDismissError = { vm.dismissError(it) },
@@ -444,6 +446,7 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
                                 chatListState = chatListState,
                                 enableWebSearch = enableWebSearch,
                                 currentChatModel = currentChatModel,
+                                inputDraftLoading = inputDraftLoading,
                                 bigScreen = false,
                                 errors = errors,
                                 onDismissError = { vm.dismissError(it) },
@@ -480,6 +483,7 @@ private fun ChatPageContent(
     chatListState: LazyListState,
     enableWebSearch: Boolean,
     currentChatModel: Model?,
+    inputDraftLoading: Boolean,
     errors: List<ChatError>,
     onDismissError: (Uuid) -> Unit,
     onClearAllErrors: () -> Unit,
@@ -585,6 +589,12 @@ private fun ChatPageContent(
                         vm.stopGeneration()
                     },
                     enableSearch = enableWebSearch,
+                    inputDraftLoading = inputDraftLoading,
+                    inputDraftEnabled = conversation.currentMessages.isNotEmpty(),
+                    onGenerateInputDraft = {
+                        vm.generateInputDraft(conversation)
+                    },
+                    onCancelInputDraft = vm::cancelInputDraft,
                     onToggleSearch = {
                         vm.toggleWebSearch()
                     },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -603,6 +603,7 @@ private fun ChatPageContent(
                             toaster.show("请先选择模型", type = ToastType.Error)
                             return@ChatInput
                         }
+                        vm.finishInputDraft()
                         if (inputState.isEditing()) {
                             vm.handleMessageEdit(
                                 parts = inputState.getContents(),
@@ -617,6 +618,7 @@ private fun ChatPageContent(
                         inputState.clearInput()
                     },
                     onLongSendClick = {
+                        vm.finishInputDraft()
                         if (inputState.isEditing()) {
                             vm.handleMessageEdit(
                                 parts = inputState.getContents(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -571,6 +571,16 @@ class ChatVM(
         lastInputDraftText = null
     }
 
+    /** Stops draft streaming while preserving the current text for send/edit actions. */
+    fun finishInputDraft() {
+        inputDraftGeneration++
+        inputDraftJob?.cancel()
+        inputDraftJob = null
+        _inputDraftLoading.value = false
+        originalInputDraftText = null
+        lastInputDraftText = null
+    }
+
     private fun restoreInputDraftIfSafe(generation: Long) {
         if (generation != inputDraftGeneration) return
         val streamedText = lastInputDraftText ?: return

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flatMapLatest
@@ -110,6 +111,12 @@ class ChatVM(
     val conversation: StateFlow<Conversation> = chatService.getConversationFlow(_conversationId)
     var chatListInitialized by mutableStateOf(false) // 聊天列表是否已经滚动到底部
     private var contextPreviewJob: Job? = null
+    private var inputDraftJob: Job? = null
+    private var inputDraftGeneration = 0L
+    private var originalInputDraftText: String? = null
+    private var lastInputDraftText: String? = null
+    private val _inputDraftLoading = MutableStateFlow(false)
+    val inputDraftLoading = _inputDraftLoading.asStateFlow()
     val contextPreviewState = MutableStateFlow<UiState<ContextPreview>>(UiState.Idle)
 
     val hookHistoryState: StateFlow<UiState<List<HookRunHistory>>> = hookRepository
@@ -156,6 +163,7 @@ class ChatVM(
 
     override fun onCleared() {
         contextPreviewJob?.cancel()
+        inputDraftJob?.cancel()
         super.onCleared()
         // 移除对话引用
         chatService.removeConversationReference(_conversationId)
@@ -493,6 +501,81 @@ class ChatVM(
     fun generateSuggestion(conversation: Conversation) {
         viewModelScope.launch {
             chatService.generateSuggestion(_conversationId, conversation)
+        }
+    }
+
+    fun generateInputDraft(conversation: Conversation) {
+        if (inputDraftJob?.isActive == true) return
+        val generation = ++inputDraftGeneration
+        val originalText = inputState.textContent.text.toString()
+        originalInputDraftText = originalText
+        lastInputDraftText = ""
+        inputState.setMessageText("")
+        inputDraftJob = viewModelScope.launch {
+            _inputDraftLoading.value = true
+            try {
+                val completedDraft = chatService.generateInputDraft(
+                    conversationId = _conversationId,
+                    conversation = conversation,
+                ) streamUpdate@{ partial ->
+                    if (generation != inputDraftGeneration) return@streamUpdate
+                    val currentText = inputState.textContent.text.toString()
+                    if (currentText != lastInputDraftText) {
+                        // A user/ASR edit wins. Invalidate before cancelling so late chunks are ignored.
+                        inputDraftGeneration++
+                        inputDraftJob?.cancel()
+                        inputDraftJob = null
+                        _inputDraftLoading.value = false
+                        originalInputDraftText = null
+                        lastInputDraftText = null
+                        return@streamUpdate
+                    }
+                    lastInputDraftText = partial
+                    inputState.setMessageText(partial)
+                }
+                if (generation == inputDraftGeneration &&
+                    inputState.textContent.text.toString() == lastInputDraftText
+                ) {
+                    lastInputDraftText = completedDraft
+                    inputState.setMessageText(completedDraft)
+                }
+            } catch (error: CancellationException) {
+                restoreInputDraftIfSafe(generation)
+                throw error
+            } catch (error: Throwable) {
+                restoreInputDraftIfSafe(generation)
+                chatService.addError(
+                    error = error,
+                    conversationId = _conversationId,
+                    title = context.getString(R.string.error_title_generate_input_draft),
+                )
+            } finally {
+                if (generation == inputDraftGeneration) {
+                    _inputDraftLoading.value = false
+                    inputDraftJob = null
+                    originalInputDraftText = null
+                    lastInputDraftText = null
+                }
+            }
+        }
+    }
+
+    fun cancelInputDraft() {
+        val generation = inputDraftGeneration
+        restoreInputDraftIfSafe(generation)
+        inputDraftGeneration++
+        inputDraftJob?.cancel()
+        inputDraftJob = null
+        _inputDraftLoading.value = false
+        originalInputDraftText = null
+        lastInputDraftText = null
+    }
+
+    private fun restoreInputDraftIfSafe(generation: Long) {
+        if (generation != inputDraftGeneration) return
+        val streamedText = lastInputDraftText ?: return
+        if (inputState.textContent.text.toString() == streamedText) {
+            inputState.setMessageText(originalInputDraftText.orEmpty())
         }
     }
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1982,5 +1982,10 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="workspace_cwd_set_assistant_default">アシスタントのデフォルトとして設定</string>
   <string name="subagent_step_tool">ツール呼び出し</string>
   <string name="extensions_subagents_open">サブエージェントプロファイルを開く</string>
+  <string name="input_draft_generate">返信の下書きを作成</string>
+  <string name="input_draft_cancel">返信の下書き作成をキャンセル</string>
+  <string name="input_draft_empty_conversation">会話のコンテキストがまだありません</string>
+  <string name="input_draft_model_unavailable">提案モデルまたは高速モデルを選択してください</string>
+  <string name="error_title_generate_input_draft">返信の下書きを生成できませんでした</string>
 </resources>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1982,5 +1982,10 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="workspace_cwd_set_assistant_default">어시스턴트 기본값으로 설정</string>
   <string name="subagent_step_tool">도구 호출</string>
   <string name="extensions_subagents_open">서브 에이전트 프로필 열기</string>
+  <string name="input_draft_generate">답장 초안 작성</string>
+  <string name="input_draft_cancel">답장 초안 작성 취소</string>
+  <string name="input_draft_empty_conversation">아직 대화 문맥이 없습니다</string>
+  <string name="input_draft_model_unavailable">제안 모델 또는 빠른 모델을 먼저 선택하세요</string>
+  <string name="error_title_generate_input_draft">답장 초안 생성 실패</string>
 </resources>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1982,5 +1982,10 @@
   <string name="workspace_cwd_set_assistant_default">Установить по умолчанию для ассистента</string>
   <string name="subagent_step_tool">Вызов инструмента</string>
   <string name="extensions_subagents_open">Открыть профиль субагента</string>
+  <string name="input_draft_generate">Написать черновик ответа</string>
+  <string name="input_draft_cancel">Отменить создание черновика</string>
+  <string name="input_draft_empty_conversation">Контекст беседы пока отсутствует</string>
+  <string name="input_draft_model_unavailable">Сначала выберите модель предложений или быструю модель</string>
+  <string name="error_title_generate_input_draft">Не удалось создать черновик ответа</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1996,5 +1996,10 @@
   <string name="workspace_cwd_set_assistant_default">設為助手預設</string>
   <string name="subagent_step_tool">工具呼叫</string>
   <string name="extensions_subagents_open">開啟子代理設定檔</string>
+  <string name="input_draft_generate">撰寫回覆草稿</string>
+  <string name="input_draft_cancel">取消回覆草稿</string>
+  <string name="input_draft_empty_conversation">尚無對話上下文</string>
+  <string name="input_draft_model_unavailable">請先選擇建議模型或快速模型</string>
+  <string name="error_title_generate_input_draft">回覆草稿生成失敗</string>
 </resources>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -2153,5 +2153,10 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="setting_provider_page_import_invalid_format">导入格式无效</string>
   <string name="setting_provider_page_clipboard_empty">剪贴板为空</string>
   <string name="workspace_cwd_set_assistant_default">设为助手默认值</string>
+  <string name="input_draft_generate">写回复草稿</string>
+  <string name="input_draft_cancel">取消回复草稿</string>
+  <string name="input_draft_empty_conversation">暂无会话上下文</string>
+  <string name="input_draft_model_unavailable">请先选择建议模型或快速模型</string>
+  <string name="error_title_generate_input_draft">回复草稿生成失败</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2164,5 +2164,10 @@
   <string name="hook_error_memory_experience_dedup_failed">The existing memory could not be checked for an equivalent experience.</string>
   <string name="hook_error_memory_experience_schema_unsupported">The selected memory table schema cannot store a deduplicated error experience.</string>
   <string name="hook_error_memory_experience_write_failed">The error experience could not be written to the memory table.</string>
+  <string name="input_draft_generate">Write reply draft</string>
+  <string name="input_draft_cancel">Cancel reply draft</string>
+  <string name="input_draft_empty_conversation">There is no conversation context yet</string>
+  <string name="input_draft_model_unavailable">Select a suggestion or fast model first</string>
+  <string name="error_title_generate_input_draft">Reply draft generation failed</string>
 </resources>
 


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #169

## 变更说明 | Changes

- 在聊天输入栏的 `+` 按钮附近增加常驻、可见的回复草稿操作及独立 loading/cancel 状态。
- 使用专用 User 角色提示词，根据最近会话上下文流式生成完整回复，并直接写入可编辑输入框。
- 开始生成时缓存并覆盖已有输入；取消或失败时，仅在输入仍未被用户修改的安全条件下恢复原文。
- 模型选择复用 `suggestionModelId`，不可用时回退到 `fastModelId`；使用后台文本生成参数，关闭 reasoning/tools。
- 草稿使用独立、生命周期绑定的 coroutine Job，不调用 `sendMessage`，不新增或持久化消息，也不修改会话历史。
- 使用 generation token 与最后流式文本比对，防止取消、失败或用户编辑后的迟到 chunk 覆盖输入；发送或编辑消息前会先终止草稿流并保留当前草稿。
- 草稿生成期间保守阻止启动 ASR；已有录音仍可停止。
- 添加英文、简体中文、繁体中文、日文、韩文和俄文标签、错误文案及 accessibility description。

## 验收条件 | Acceptance criteria

- [x] 输入栏 `+` 附近显示回复草稿按钮，空会话时禁用。
- [x] 草稿流式覆盖输入框已有文本，成功后可继续编辑并通过原发送流程发送。
- [x] 取消或错误时安全恢复原输入；用户编辑和发送/编辑操作不会被迟到流覆盖。
- [x] 使用 `suggestionModelId -> fastModelId`，且与主消息生成/取消 Job 独立。
- [x] 草稿路径不调用 `sendMessage`，不新增消息或修改历史。
- [x] 文案与无障碍描述已本地化。

## UI 截图 / 录屏 | UI evidence

未提供：当前工作区没有可运行 Android 构建或设备环境。请在有 Java/Gradle 的环境中按下方清单进行 UI 验收并补充截图。

## 测试 | Testing

- 命令 / 检查：`git diff --check origin/release/rikka-arsucar..HEAD`
- 结果：通过，无空白错误。
- 命令 / 检查：使用 Python `xml.etree.ElementTree` 解析全部 `values*/strings.xml`，检查重复 string key 及所有新增资源在六个 locale 中存在。
- 结果：通过，XML 均有效、无重复 key、所需资源完整。
- 命令 / 检查：静态 wiring/invariant 检查（模型 fallback、`streamText`、`backgroundTextGenerationParams`、最近 8 条上下文、无新增 `sendMessage`/历史持久化调用、send/edit 前停止草稿流）。
- 结果：通过。
- **未运行 Gradle 构建、单元测试、UI 测试或设备测试：当前 workspace 没有 Java/Gradle。**

### Manual test checklist

- [ ] 有上下文时点击草稿按钮，确认文本逐步流入输入框且没有新增聊天气泡。
- [ ] 输入框已有文本时生成，确认原文被覆盖；中途取消后恢复原文。
- [ ] 模拟网络/模型错误，确认显示聊天错误并安全恢复原文。
- [ ] 流式期间手动编辑，确认流停止且迟到 chunk 不覆盖编辑内容。
- [ ] 流式期间发送或编辑消息，确认先停止草稿流，发送的是当前输入且之后无迟到覆盖。
- [ ] 与主回复生成并行，确认两个 loading/cancel 状态互不劫持。
- [ ] 空会话时按钮禁用；无 suggestion/fast 模型时显示明确错误。
- [ ] 草稿生成期间不能启动 ASR，已有录音仍可停止。
- [ ] 检查浅色/深色主题、触摸目标、loading 指示和屏幕阅读器描述。

## 数据兼容 | Data compatibility

N/A：无数据库、备份格式、配置 schema 或 API 迁移；草稿只存在于当前输入状态。

## 风险与回滚 | Risks and rollback

风险主要是不同 provider 的流式 chunk 行为及 Compose 输入交互尚未在设备上验证。可通过回滚本 PR 的两个提交完整移除该功能，不涉及数据迁移。

## 已知限制 | Known limitations

当前工作区无法执行 Android 构建和设备验收；需由 CI 或具备 Java/Gradle 的开发环境完成上述手工测试。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
