### PR TITLE
fix(ui): 侧栏更新信息卡片 changelog 可滚动

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UpdateCard.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UpdateCard.kt
@@ -116,7 +116,9 @@ fun UpdateCard(vm: ChatVM) {
                     MarkdownBlock(
                         content = info.changelog,
                         style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.heightIn(max = 200.dp)
+                        modifier = Modifier
+                            .heightIn(max = 200.dp)
+                            .verticalScroll(rememberScrollState()),
                     )
                 }
             }


### PR DESCRIPTION
## 关联任务 | Linked issue

Fixes #172

## 变更说明 | Changes

侧栏「发现新版本」预览卡片对 changelog 使用了 `heightIn(max = 200.dp)`，但未挂 `verticalScroll`，长更新说明被裁切且无法滚动。

在 `UpdateCard` 预览区的 `MarkdownBlock` 上补充 `verticalScroll(rememberScrollState())`，与详情 bottom sheet 内 changelog 的滚动处理一致；仍保留 200dp 高度上限，点击卡片打开详情行为不变。

## 验收条件 | Acceptance criteria

- [ ] 侧栏更新卡片在 changelog 超过约 200dp 时可在卡片内垂直滚动
- [ ] 短 changelog 时卡片高度随内容收缩，不出现多余空白滚动
- [ ] 点击卡片仍可打开详情 bottom sheet；关闭按钮仍可 dismiss 卡片
- [ ] 详情 sheet 内 changelog 滚动行为不受影响

## UI 截图 / 录屏 | UI evidence

修复点：预览卡片 changelog 区域可滚动。工作区无真机，请在 PC/真机验证。

## 测试 | Testing

- 命令 / 检查：静态 diff 审查 `UpdateCard.kt`；确认 `verticalScroll` / `rememberScrollState` 已有 import（详情 sheet 已用）
- 结果：工作区无 Java/Gradle，无法 assemble 或真机验证，由 PC 或 GitHub CI 验证

## 数据兼容 | Data compatibility

N/A（纯 UI modifier，无数据/配置变更）

## 风险与回滚 | Risks and rollback

- 风险：侧栏抽屉若存在父级滚动，可能出现嵌套滚动手势竞争（预览区高度有限，影响较小）
- 回滚：revert 本 PR 单 commit

## 已知限制 | Known limitations

N/A

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
