### PR TITLE
fix(#204,#205): scrollable semantic memory dialogs, non-destructive injection dedupe

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
@@ -4,6 +4,7 @@ import me.rerere.ai.core.MessageRole
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.data.ai.prompts.BuiltinPromptRegistry
+import me.rerere.rikkahub.data.datastore.boundPresetInjectionIds
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.InjectionPosition
 import me.rerere.rikkahub.data.model.PresetEntry

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
@@ -95,7 +95,13 @@ internal fun collectInjections(
     val effectiveModeInjectionIds = if (assistant.allowConversationPromptInjection) {
         conversationModeInjectionIds
     } else {
+        // #205: 组装期只读去重（替代 #201 的加载期持久化删除）。
+        // 跳过与已绑定预设条目（启用条目 + Reference 引用的全局 id，语义与 #201 的
+        // boundPresetInjectionIds 一致）重复的直连 id；直连绑定数据保留在 DataStore 不销毁，
+        // 关闭预设后直连恢复生效、system 消息不残留旧注入。
         assistant.modeInjectionIds
+            .filterNot { it in boundPresetInjectionIds(assistant.presetIds, presets) }
+            .toSet()
     }
     val effectiveLorebookIds = if (assistant.allowConversationPromptInjection) {
         conversationLorebookIds

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/AssistantExtensionIds.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/AssistantExtensionIds.kt
@@ -36,32 +36,21 @@ fun Assistant.pruneExtensionIds(settings: Settings): Assistant {
 }
 
 /**
- * #201: 去掉与已绑定 preset 的 entry id（及未迁移旧 [Preset.modeInjectionIds]）重复的直连，
- * 消除「preset 路径 + assistant 直连」双路径残留；与 preset 无关的独立注入保留。
+ * 计算「经预设路径投递」的注入 id 集合（#201/#205 语义）：
+ * - 已迁移（entries）：仅启用条目算重复（禁用的条目不会注入，直连是唯一生效路径，须保留）；
+ *   Reference 条目额外计入其引用的全局 id，消除 reference 路径双注入残留。
+ * - 未迁移（旧 modeInjectionIds）：扣除 disabledEntryIds（effectiveInjectionIds）后同样算重复。
+ *
+ * 用途：
+ * - PromptInjectionTransformer.collectInjections 组装期只读过滤直连绑定（#205，不再持久化删除）；
+ * - ExtensionSelector 的「预设管理」UI 标记（presetManagedIds）。
  */
-internal fun Assistant.withModeInjectionsDedupedAgainstPresets(
-    presets: List<Preset>,
-    validModeInjectionIds: Set<Uuid>,
-): Assistant {
-    val boundPresetEntryIds = boundPresetInjectionIds(presetIds, presets)
-    return copy(
-        modeInjectionIds = modeInjectionIds
-            .filter { it !in boundPresetEntryIds }
-            .filter { it in validModeInjectionIds }
-            .toSet(),
-    )
-}
-
 internal fun boundPresetInjectionIds(
     presetIds: Set<Uuid>,
     presets: List<Preset>,
 ): Set<Uuid> = presetIds
     .flatMap { presetId ->
         val preset = presets.firstOrNull { it.id == presetId } ?: return@flatMap emptyList()
-        // 只统计「实际经 preset 路径投递」的 id（#201）：
-        // - 已迁移（entries）：仅启用条目算重复（禁用的条目不会注入，直连是唯一生效路径，须保留）；
-        //   Reference 条目额外计入其引用的全局 id，消除 reference 路径双注入残留。
-        // - 未迁移（旧 modeInjectionIds）：扣除 disabledEntryIds（effectiveInjectionIds）后同样算重复。
         val entryIds = preset.entries
             .filter { it.enabled }
             .flatMap { entry ->

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -459,11 +459,17 @@ class SettingsStore(
                     }
                 },
                 assistants = settings.assistants.distinctBy { it.id }.map { assistant ->
-                    // #201: 过滤无效引用，并去掉与已绑定 preset entries 同 id 的直连（消除双路径）。
+                    // #205: 只做无效引用过滤；不再像 #201 那样在加载期删除与已绑定 preset entries
+                    // 重复的直连绑定（改为 PromptInjectionTransformer 组装期只读过滤，直连数据保留在
+                    // DataStore 不销毁，用户可随时在「独立注入」中管理）。
                     assistant.copy(
                         // 过滤掉不存在的 MCP 服务器 ID
                         mcpServers = assistant.mcpServers.filter { serverId ->
                             serverId in validMcpServerIds
+                        }.toSet(),
+                        // 过滤掉不存在的模式注入 ID
+                        modeInjectionIds = assistant.modeInjectionIds.filter { id ->
+                            id in validModeInjectionIds
                         }.toSet(),
                         // 过滤掉不存在的 Lorebook ID
                         lorebookIds = assistant.lorebookIds.filter { id ->
@@ -477,9 +483,6 @@ class SettingsStore(
                         presetIds = assistant.presetIds.filter { id ->
                             id in validPresetIds
                         }.toSet()
-                    ).withModeInjectionsDedupedAgainstPresets(
-                        presets = migratedPresets,
-                        validModeInjectionIds = validModeInjectionIds,
                     )
                 },
                 ttsProviders = settings.ttsProviders.distinctBy { it.id },

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ExtensionContent.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ExtensionContent.kt
@@ -102,12 +102,16 @@ fun ModeInjectionsContent(
     modifier: Modifier = Modifier,
     onManage: (() -> Unit)? = null,
     onEdit: ((PromptInjection.ModeInjection) -> Unit)? = null,
+    /** When set, dual-bound / preset-managed ids show a supporting note (#205). */
+    presetManagedIds: Set<Uuid> = emptySet(),
 ) {
+    val presetManagedNote = stringResource(R.string.extension_content_preset_managed_injection)
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         items(modeInjections) { injection ->
+            val isPresetManaged = injection.id in presetManagedIds
             ListItem(
                 modifier = Modifier.clickable(enabled = onEdit != null || onManage != null) {
                     if (onEdit != null) onEdit(injection) else onManage?.invoke()
@@ -115,6 +119,15 @@ fun ModeInjectionsContent(
                 headlineContent = {
                     Text(injection.name.ifBlank { stringResource(R.string.extension_content_unnamed) })
                 },
+                supportingContent = if (isPresetManaged) {
+                    {
+                        Text(
+                            text = presetManagedNote,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                        )
+                    }
+                } else null,
                 trailingContent = {
                     Switch(
                         checked = selectedIds.contains(injection.id),

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ExtensionSelector.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ExtensionSelector.kt
@@ -275,14 +275,14 @@ fun ExtensionSelector(
                 }
 
                 4 -> {
-                    // #201: 已由已绑定预设「实际投递」的注入会被 settings 清理去重，勾选必然被回滚。
-                    // 这里在非会话模式下把它们过滤出「独立注入」列表，避免出现「勾了不生效」。
-                    val visibleInjections = if (useConversationInjections) {
-                        settings.modeInjections
+                    // #205: 双绑直连数据保留在 DataStore；组装期只读过滤避免双注入。
+                    // 独立注入列表展示全部条目（含预设已投递），预设管理项带说明文案，允许取消勾选管理直连绑定。
+                    val presetManagedIds = if (useConversationInjections) {
+                        emptySet()
                     } else {
-                        val presetManagedIds = boundPresetInjectionIds(assistant.presetIds, settings.presets)
-                        settings.modeInjections.filter { it.id !in presetManagedIds }
+                        boundPresetInjectionIds(assistant.presetIds, settings.presets)
                     }
+                    val visibleInjections = settings.modeInjections
                     if (visibleInjections.isNotEmpty()) {
                         ModeInjectionsContent(
                             modeInjections = visibleInjections,
@@ -301,6 +301,7 @@ fun ExtensionSelector(
                             },
                             onManage = onNavigateToPrompts,
                             onEdit = { modeInjectionEditState.open(it) },
+                            presetManagedIds = presetManagedIds,
                         )
                     } else {
                         ExtensionEmptyState(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantExtensionsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantExtensionsPage.kt
@@ -50,6 +50,7 @@ import me.rerere.hugeicons.stroke.Puzzle
 import me.rerere.rikkahub.R
 import kotlinx.coroutines.launch
 import me.rerere.rikkahub.Screen
+import me.rerere.rikkahub.data.datastore.boundPresetInjectionIds
 import me.rerere.rikkahub.data.datastore.withModeInjectionsPreservingPresetSnapshots
 import me.rerere.rikkahub.data.files.SkillMetadata
 import me.rerere.rikkahub.data.model.Lorebook
@@ -243,6 +244,10 @@ fun AssistantExtensionsPage(id: String, initialPage: Int = 0) {
                                             vm.update(assistant.copy(modeInjectionIds = newIds))
                                         },
                                         onEdit = { modeInjectionEditState.open(it) },
+                                        presetManagedIds = boundPresetInjectionIds(
+                                            assistant.presetIds,
+                                            settings.presets,
+                                        ),
                                     )
                                 }
                                 TextButton(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemoryBrowserPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemoryBrowserPage.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
@@ -37,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.rerere.hugeicons.HugeIcons
@@ -412,11 +415,19 @@ private fun MemoryEditDialog(
     var importance by remember { mutableStateOf(memory.importance.toFloat()) }
     var isCore by remember { mutableStateOf(memory.isCore) }
 
+    val configuration = LocalConfiguration.current
+    val formMaxHeight = (configuration.screenHeightDp * 0.6f).dp
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(if (isNew) "添加记忆" else "编辑记忆") },
         text = {
-            Column(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = formMaxHeight)
+                    .verticalScroll(rememberScrollState()),
+            ) {
                 OutlinedTextField(
                     value = content,
                     onValueChange = { content = it },
@@ -479,17 +490,30 @@ private fun EvictionConfirmDialog(
     onConfirm: (List<EpisodicMemoryEntity>) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val configuration = LocalConfiguration.current
+    val listMaxHeight = (configuration.screenHeightDp * 0.5f).dp
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("清理低重要性记忆") },
         text = {
-            Column {
+            Column(modifier = Modifier.fillMaxWidth()) {
                 Text("以下 ${candidates.size} 条低重要性记忆建议清理:")
-                Text(
-                    text = candidates.joinToString("\n") { "- ${"\u2605".repeat(it.importance)} ${it.content.take(60)}" },
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(top = 8.dp),
-                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = listMaxHeight)
+                        .verticalScroll(rememberScrollState())
+                        .padding(top = 8.dp),
+                ) {
+                    candidates.forEach { memory ->
+                        Text(
+                            text = "- ${"\u2605".repeat(memory.importance)} ${memory.content.take(60)}",
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(bottom = 4.dp),
+                        )
+                    }
+                }
             }
         },
         confirmButton = {

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -573,6 +573,7 @@
   <string name="export_to_file_desc">保存为JSON文件</string>
   <string name="extension_content_manage">管理</string>
   <string name="extension_content_preset_entries_count">%1$d 个条目</string>
+  <string name="extension_content_preset_managed_injection">已由已绑定预设投递；直连绑定会保留。取消勾选可移除直连。预设条目启用期间走预设路径（不会双注入）。</string>
   <string name="extension_content_unnamed">未命名</string>
   <string name="extension_content_unnamed_lorebook">未命名Lorebook</string>
   <string name="extension_content_unnamed_preset">未命名预设</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,6 +589,7 @@
   <string name="export_to_file_desc">Save as JSON file</string>
   <string name="extension_content_manage">Manage</string>
   <string name="extension_content_preset_entries_count">%1$d entries</string>
+  <string name="extension_content_preset_managed_injection">Also delivered by a bound preset; direct binding is kept. Uncheck to remove the direct binding. Delivery uses the preset path while the preset entry is enabled (no double inject).</string>
   <string name="extension_content_unnamed">Unnamed</string>
   <string name="extension_content_unnamed_lorebook">Unnamed Lorebook</string>
   <string name="extension_content_unnamed_preset">Unnamed Preset</string>

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformerTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformerTest.kt
@@ -2079,4 +2079,165 @@ class PromptInjectionTransformerTest {
         assertTrue(systemText.indexOf("Custom") < systemText.indexOf("Reference"))
     }
     // endregion
+
+    // region #205 assembly-time read-only dedupe tests
+    @Test
+    fun `dual-bound direct and preset entry should inject preset path content once`() {
+        // #205: 直连 + 启用预设条目双绑时，组装期只读过滤直连（不再加载期删除），
+        // 输出只有预设路径一条注入，不出现重复、也不注入被过滤的直连内容。
+        val sharedId = Uuid.random()
+        val presetId = Uuid.random()
+        val marker = "Preset snapshot marker"
+        val globalInjection = createModeInjection(
+            id = sharedId,
+            position = InjectionPosition.AFTER_SYSTEM_PROMPT,
+            content = "Global direct content",
+        )
+        val preset = Preset(
+            id = presetId,
+            entries = listOf(
+                PresetEntry.Custom(
+                    id = sharedId,
+                    order = 0,
+                    position = InjectionPosition.AFTER_SYSTEM_PROMPT,
+                    content = marker,
+                ),
+            ),
+        )
+        val messages = listOf(UIMessage.system("System prompt"), UIMessage.user("Hello"))
+
+        val result = transformMessages(
+            messages = messages,
+            assistant = createAssistant(
+                modeInjectionIds = setOf(sharedId),
+                presetIds = setOf(presetId),
+            ),
+            modeInjections = listOf(globalInjection),
+            lorebooks = emptyList(),
+            presets = listOf(preset),
+        )
+
+        val systemText = getMessageText(result.first())
+        // 预设快照内容注入一次；直连内容被过滤（不出现），保证双绑不双注入
+        assertEquals(1, systemText.split(marker).size - 1)
+        assertFalse(systemText.contains("Global direct content"))
+    }
+
+    @Test
+    fun `direct binding matching reference entry id should not double inject`() {
+        // #205: 直连 id 与 Reference 条目 id 相同（entry.id 计入 boundPresetInjectionIds），
+        // 组装期过滤直连，仅经 reference 路径注入一次，消除 reference 路径双注入残留。
+        val entryId = Uuid.random()
+        val targetId = Uuid.random()
+        val presetId = Uuid.random()
+        val directInjection = createModeInjection(id = entryId, content = "Direct entry-id content")
+        val targetInjection = createModeInjection(id = targetId, content = "Referenced target content")
+        val preset = Preset(
+            id = presetId,
+            entries = listOf(
+                PresetEntry.Reference(
+                    id = entryId,
+                    order = 0,
+                    modeInjectionId = targetId,
+                ),
+            ),
+        )
+        val messages = listOf(UIMessage.system("System"), UIMessage.user("Hello"))
+
+        val result = transformMessages(
+            messages = messages,
+            assistant = createAssistant(
+                modeInjectionIds = setOf(entryId),
+                presetIds = setOf(presetId),
+            ),
+            modeInjections = listOf(directInjection, targetInjection),
+            lorebooks = emptyList(),
+            presets = listOf(preset),
+        )
+
+        val systemText = getMessageText(result.first())
+        // 仅 reference 目标注入一次；entry.id 的直连被过滤，不出现直连内容
+        assertEquals(1, systemText.split("Referenced target content").size - 1)
+        assertFalse(systemText.contains("Direct entry-id content"))
+    }
+
+    @Test
+    fun `disabled preset entry restores direct binding without residue`() {
+        // #205 + #201: 预设条目启用时直连被过滤（只走预设路径）；
+        // 条目禁用后直连恢复生效，且不出现「预设条目残留 + 直连」双路径。
+        val sharedId = Uuid.random()
+        val presetId = Uuid.random()
+        val globalContent = "Global direct content"
+        val snapshotContent = "Preset snapshot content"
+        val globalInjection = createModeInjection(
+            id = sharedId,
+            position = InjectionPosition.AFTER_SYSTEM_PROMPT,
+            content = globalContent,
+        )
+        val enabledPreset = Preset(
+            id = presetId,
+            entries = listOf(
+                PresetEntry.Custom(id = sharedId, order = 0, enabled = true, content = snapshotContent),
+            ),
+        )
+        val disabledPreset = enabledPreset.copy(
+            entries = listOf(
+                PresetEntry.Custom(id = sharedId, order = 0, enabled = false, content = snapshotContent),
+            ),
+        )
+        val messages = listOf(UIMessage.system("System prompt"), UIMessage.user("Hello"))
+        val assistant = createAssistant(
+            modeInjectionIds = setOf(sharedId),
+            presetIds = setOf(presetId),
+        )
+
+        val withEntry = transformMessages(
+            messages = messages,
+            assistant = assistant,
+            modeInjections = listOf(globalInjection),
+            lorebooks = emptyList(),
+            presets = listOf(enabledPreset),
+        )
+        val afterDisable = transformMessages(
+            messages = messages,
+            assistant = assistant,
+            modeInjections = listOf(globalInjection),
+            lorebooks = emptyList(),
+            presets = listOf(disabledPreset),
+        )
+
+        val withEntryText = getMessageText(withEntry.first())
+        val afterDisableText = getMessageText(afterDisable.first())
+        // 启用：只注入预设快照内容一次，无直连内容
+        assertEquals(1, withEntryText.split(snapshotContent).size - 1)
+        assertFalse(withEntryText.contains(globalContent))
+        // 禁用：直连恢复生效且无预设残留（#201 场景：关闭预设后 system 无残留旧注入）
+        assertEquals(1, afterDisableText.split(globalContent).size - 1)
+        assertFalse(afterDisableText.contains(snapshotContent))
+    }
+
+    @Test
+    fun `collectInjections should not return duplicate ids for dual-bound direct and preset entry`() {
+        val sharedId = Uuid.random()
+        val presetId = Uuid.random()
+        val globalInjection = createModeInjection(id = sharedId, content = "shared")
+        val preset = Preset(
+            id = presetId,
+            entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap")),
+        )
+
+        val result = collectInjections(
+            messages = listOf(UIMessage.user("Hello")),
+            assistant = createAssistant(
+                modeInjectionIds = setOf(sharedId),
+                presetIds = setOf(presetId),
+            ),
+            modeInjections = listOf(globalInjection),
+            lorebooks = emptyList(),
+            presets = listOf(preset),
+        )
+
+        assertEquals(1, result.size)
+    }
+    // endregion
 }

--- a/app/src/test/java/me/rerere/rikkahub/data/datastore/ModeInjectionDirectBindingDedupeTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/datastore/ModeInjectionDirectBindingDedupeTest.kt
@@ -118,7 +118,8 @@ class ModeInjectionDirectBindingDedupeTest {
     fun `load-time pruning keeps dual-bound direct ids in DataStore`() {
         val sharedId = Uuid.random()
         val independentId = Uuid.random()
-        val injection = PromptInjection.ModeInjection(id = sharedId, content = "shared")
+        val sharedInjection = PromptInjection.ModeInjection(id = sharedId, content = "shared")
+        val independentInjection = PromptInjection.ModeInjection(id = independentId, content = "solo")
         val preset = Preset(
             entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap")),
             entriesVersion = PRESET_ENTRIES_VERSION,
@@ -128,7 +129,7 @@ class ModeInjectionDirectBindingDedupeTest {
             presetIds = setOf(preset.id),
         )
         val settings = Settings(init = true).copy(
-            modeInjections = listOf(injection),
+            modeInjections = listOf(sharedInjection, independentInjection),
             presets = listOf(preset),
             assistants = listOf(assistant),
         )

--- a/app/src/test/java/me/rerere/rikkahub/data/datastore/ModeInjectionDirectBindingDedupeTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/datastore/ModeInjectionDirectBindingDedupeTest.kt
@@ -5,221 +5,155 @@ import me.rerere.rikkahub.data.model.PRESET_ENTRIES_VERSION
 import me.rerere.rikkahub.data.model.Preset
 import me.rerere.rikkahub.data.model.PresetEntry
 import me.rerere.rikkahub.data.model.PromptInjection
-import me.rerere.rikkahub.data.model.migratedWithEntries
-import me.rerere.rikkahub.utils.JsonInstant
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.uuid.Uuid
 
 /**
- * #201: assistant.modeInjectionIds 与已绑定 preset entries 同 id 时清理直连，
- * 与 preset 无关的独立注入保留；幂等。
+ * #205: 「与已绑定 preset entries 重复的 assistant.modeInjectionIds 直连」去重从
+ * 加载期持久化删除（#201）改为组装期只读过滤。
+ *
+ * 本文件覆盖：
+ * - [boundPresetInjectionIds] 语义（启用条目 / Reference 引用 id / 旧字段 / 未绑定预设），
+ *   供组装期过滤与 ExtensionSelector UI 共用；
+ * - 加载期（[Settings.withPrunedAssistantExtensionIds]）只过滤无效引用，
+ *   双绑直连数据保留在 DataStore 不销毁（#201 会静默删除 sharedId）；
+ * - 组装输出不含重复注入、关闭预设后不残留，见 PromptInjectionTransformerTest。
  */
 class ModeInjectionDirectBindingDedupeTest {
+
+    // ---- boundPresetInjectionIds 语义（#201/#205） ----
+
     @Test
-    fun `dedupe removes direct ids that match bound migrated preset entry ids`() {
+    fun `bound ids include enabled custom entry id`() {
         val sharedId = Uuid.random()
-        val independentId = Uuid.random()
-        val injections = listOf(
-            PromptInjection.ModeInjection(id = sharedId, content = "from preset"),
-            PromptInjection.ModeInjection(id = independentId, content = "independent"),
-        )
-        val preset = Preset(modeInjectionIds = setOf(sharedId))
-            .migratedWithEntries(injections)
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId, independentId),
-            presetIds = setOf(preset.id),
-        )
-        val validIds = injections.map { it.id }.toSet()
-
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
-            presets = listOf(preset),
-            validModeInjectionIds = validIds,
+        val preset = Preset(
+            entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap")),
+            entriesVersion = PRESET_ENTRIES_VERSION,
         )
 
-        assertEquals(setOf(independentId), cleaned.modeInjectionIds)
-        assertTrue(preset.entries.any { it.id == sharedId })
+        assertEquals(
+            setOf(sharedId),
+            boundPresetInjectionIds(setOf(preset.id), listOf(preset)),
+        )
     }
 
     @Test
-    fun `dedupe removes direct ids that match bound legacy preset modeInjectionIds`() {
-        val sharedId = Uuid.random()
-        val independentId = Uuid.random()
-        val legacyPreset = Preset(modeInjectionIds = setOf(sharedId))
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId, independentId),
-            presetIds = setOf(legacyPreset.id),
-        )
-        val validIds = setOf(sharedId, independentId)
-
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
-            presets = listOf(legacyPreset),
-            validModeInjectionIds = validIds,
-        )
-
-        assertEquals(setOf(independentId), cleaned.modeInjectionIds)
-        assertFalse(legacyPreset.hasEntries())
-    }
-
-    @Test
-    fun `dedupe keeps direct id when bound preset entry is disabled`() {
+    fun `bound ids exclude disabled custom entry id`() {
         val sharedId = Uuid.random()
         val preset = Preset(
             entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap", enabled = false)),
             entriesVersion = PRESET_ENTRIES_VERSION,
         )
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId),
-            presetIds = setOf(preset.id),
-        )
 
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
-            presets = listOf(preset),
-            validModeInjectionIds = setOf(sharedId),
-        )
-
-        assertEquals(setOf(sharedId), cleaned.modeInjectionIds)
+        assertTrue(boundPresetInjectionIds(setOf(preset.id), listOf(preset)).isEmpty())
     }
 
     @Test
-    fun `dedupe keeps direct id disabled in legacy preset`() {
-        val sharedId = Uuid.random()
-        val legacyPreset = Preset(
-            modeInjectionIds = setOf(sharedId),
-            disabledEntryIds = setOf(sharedId),
-        )
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId),
-            presetIds = setOf(legacyPreset.id),
-        )
-
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
-            presets = listOf(legacyPreset),
-            validModeInjectionIds = setOf(sharedId),
-        )
-
-        assertEquals(setOf(sharedId), cleaned.modeInjectionIds)
-    }
-
-    @Test
-    fun `dedupe removes direct id referenced by bound preset reference entry`() {
-        val sharedId = Uuid.random()
+    fun `bound ids include reference entry id and referenced global id`() {
+        val entryId = Uuid.random()
+        val globalId = Uuid.random()
         val preset = Preset(
-            entries = listOf(PresetEntry.Reference(modeInjectionId = sharedId)),
+            entries = listOf(PresetEntry.Reference(id = entryId, modeInjectionId = globalId)),
             entriesVersion = PRESET_ENTRIES_VERSION,
         )
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId),
-            presetIds = setOf(preset.id),
-        )
 
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
-            presets = listOf(preset),
-            validModeInjectionIds = setOf(sharedId),
+        assertEquals(
+            setOf(entryId, globalId),
+            boundPresetInjectionIds(setOf(preset.id), listOf(preset)),
         )
-
-        assertTrue(cleaned.modeInjectionIds.isEmpty())
     }
 
     @Test
-    fun `dedupe keeps direct id when preset entry is disabled but reference entry enabled`() {
-        val sharedId = Uuid.random()
+    fun `bound ids exclude disabled reference entry`() {
+        val entryId = Uuid.random()
+        val globalId = Uuid.random()
         val preset = Preset(
             entries = listOf(
-                PresetEntry.Custom(id = sharedId, content = "snap", enabled = false),
-                PresetEntry.Reference(modeInjectionId = sharedId, enabled = true),
+                PresetEntry.Reference(id = entryId, modeInjectionId = globalId, enabled = false),
             ),
             entriesVersion = PRESET_ENTRIES_VERSION,
         )
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId),
-            presetIds = setOf(preset.id),
-        )
 
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
-            presets = listOf(preset),
-            validModeInjectionIds = setOf(sharedId),
-        )
-
-        assertTrue(cleaned.modeInjectionIds.isEmpty())
+        assertTrue(boundPresetInjectionIds(setOf(preset.id), listOf(preset)).isEmpty())
     }
 
     @Test
-    fun `dedupe keeps direct ids when assistant does not bind the preset`() {
+    fun `bound ids include legacy effective injection ids minus disabled`() {
+        val activeId = Uuid.random()
+        val disabledId = Uuid.random()
+        val legacyPreset = Preset(
+            modeInjectionIds = setOf(activeId, disabledId),
+            disabledEntryIds = setOf(disabledId),
+        )
+
+        assertEquals(
+            setOf(activeId),
+            boundPresetInjectionIds(setOf(legacyPreset.id), listOf(legacyPreset)),
+        )
+    }
+
+    @Test
+    fun `bound ids ignore preset not bound by assistant`() {
         val sharedId = Uuid.random()
         val preset = Preset(
-            entries = listOf(PresetEntry.Custom(id = sharedId, content = "snapshot")),
+            entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap")),
+            entriesVersion = PRESET_ENTRIES_VERSION,
+        )
+
+        assertTrue(boundPresetInjectionIds(emptySet(), listOf(preset)).isEmpty())
+    }
+
+    @Test
+    fun `bound ids ignore preset missing from presets list`() {
+        val presetId = Uuid.random()
+
+        assertTrue(boundPresetInjectionIds(setOf(presetId), emptyList()).isEmpty())
+    }
+
+    // ---- 加载期不再持久化删除直连绑定（#205） ----
+
+    @Test
+    fun `load-time pruning keeps dual-bound direct ids in DataStore`() {
+        val sharedId = Uuid.random()
+        val independentId = Uuid.random()
+        val injection = PromptInjection.ModeInjection(id = sharedId, content = "shared")
+        val preset = Preset(
+            entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap")),
             entriesVersion = PRESET_ENTRIES_VERSION,
         )
         val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId),
-            presetIds = emptySet(),
+            modeInjectionIds = setOf(sharedId, independentId),
+            presetIds = setOf(preset.id),
         )
-
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
+        val settings = Settings(init = true).copy(
+            modeInjections = listOf(injection),
             presets = listOf(preset),
-            validModeInjectionIds = setOf(sharedId),
+            assistants = listOf(assistant),
         )
 
-        assertEquals(setOf(sharedId), cleaned.modeInjectionIds)
+        val pruned = settings.withPrunedAssistantExtensionIds()
+
+        // #205: 直连绑定即使与预设条目重复也不再被静默删除（#201 会删 sharedId），仅过滤无效引用。
+        assertEquals(
+            setOf(sharedId, independentId),
+            pruned.assistants.first().modeInjectionIds,
+        )
     }
 
     @Test
-    fun `dedupe drops invalid mode injection ids`() {
+    fun `load-time pruning still drops invalid mode injection ids`() {
         val validId = Uuid.random()
         val orphanId = Uuid.random()
         val assistant = Assistant(modeInjectionIds = setOf(validId, orphanId))
-
-        val cleaned = assistant.withModeInjectionsDedupedAgainstPresets(
-            presets = emptyList(),
-            validModeInjectionIds = setOf(validId),
+        val settings = Settings(init = true).copy(
+            modeInjections = listOf(PromptInjection.ModeInjection(id = validId, content = "v")),
+            assistants = listOf(assistant),
         )
 
-        assertEquals(setOf(validId), cleaned.modeInjectionIds)
-    }
+        val pruned = settings.withPrunedAssistantExtensionIds()
 
-    @Test
-    fun `dedupe is idempotent`() {
-        val sharedId = Uuid.random()
-        val independentId = Uuid.random()
-        val preset = Preset(
-            entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap")),
-            entriesVersion = PRESET_ENTRIES_VERSION,
-        )
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId, independentId),
-            presetIds = setOf(preset.id),
-        )
-        val validIds = setOf(sharedId, independentId)
-
-        val once = assistant.withModeInjectionsDedupedAgainstPresets(listOf(preset), validIds)
-        val twice = once.withModeInjectionsDedupedAgainstPresets(listOf(preset), validIds)
-
-        assertEquals(setOf(independentId), once.modeInjectionIds)
-        assertEquals(once.modeInjectionIds, twice.modeInjectionIds)
-    }
-
-    @Test
-    fun `cleaned modeInjectionIds round-trip through assistant serialization`() {
-        val sharedId = Uuid.random()
-        val independentId = Uuid.random()
-        val preset = Preset(
-            entries = listOf(PresetEntry.Custom(id = sharedId, content = "snap")),
-            entriesVersion = PRESET_ENTRIES_VERSION,
-        )
-        val assistant = Assistant(
-            modeInjectionIds = setOf(sharedId, independentId),
-            presetIds = setOf(preset.id),
-        ).withModeInjectionsDedupedAgainstPresets(
-            presets = listOf(preset),
-            validModeInjectionIds = setOf(sharedId, independentId),
-        )
-
-        val decoded = JsonInstant.decodeFromString<Assistant>(JsonInstant.encodeToString(assistant))
-
-        assertEquals(setOf(independentId), decoded.modeInjectionIds)
-        assertEquals(setOf(preset.id), decoded.presetIds)
+        assertEquals(setOf(validId), pruned.assistants.first().modeInjectionIds)
     }
 }


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #204
Closes #205

## 变更说明 | Changes

### Issue #204：语义记忆浏览器弹窗长内容不可滚动

- **MemoryEditDialog**（`SemanticMemoryBrowserPage.kt`）：内容 `Column` 增加
  `Modifier.fillMaxWidth().heightIn(max = 屏高×0.6).verticalScroll(rememberScrollState())`，
  大字体 / 横屏贴边时内容可滚动，确认/取消按钮（`confirmButton`/`dismissButton`）保持在滚动区外始终可达。
- **EvictionConfirmDialog**：候选列表由 `joinToString("\n")` 单 Text 堆叠改为
  `heightIn(max = 屏高×0.5) + verticalScroll` 的可滚动 `Column`，逐条渲染（`candidates.forEach`），
  候选 40+ 时不再溢出；按钮仍在滚动区外。
- 均沿用本仓既有规范（见 SettingProviderPage / SettingMcpPage 的 AlertDialog 滚动写法）。
- 未触碰 ModalBottomSheet 及其他代码。

### Issue #205：预设注入去重加载期静默删除 assistant 直连绑定（#201 follow-up）

**方案选择：组装期只读过滤（首选方案），不销毁用户数据。**

调研结论（先于实现完成）：

- `git show 7deb45e2b`：#201 在 `PreferencesStore.kt` 加载期 sanitize 阶段调用
  `withModeInjectionsDedupedAgainstPresets`（实现在 `AssistantExtensionIds.kt`），把与
  已绑定 preset entries 重复的 `assistant.modeInjectionIds` 直连绑定**持久化静默删除**。
- 注入组装链路唯一入口确认：`PromptInjectionTransformer.collectInjections`
  （`assistant.modeInjectionIds` 直连收集点，:98）；`ChatService` 只传对话级
  `conversation.modeInjectionIds`，子代理构造直连为空。因此组装期过滤可完整覆盖 #201 场景。

实现：

1. **`PreferencesStore.kt`**：加载期 sanitize 移除对直连绑定的持久化删除，恢复为仅过滤无效引用
   （保留预设快照迁移、`migratedPresets`、#182 `withModeInjectionsPreservingPresetSnapshots` 等逻辑不变）。
2. **`PromptInjectionTransformer.collectInjections`**：对 `assistant.modeInjectionIds` 做组装期只读过滤，
   跳过与 `boundPresetInjectionIds(assistant.presetIds, presets)`（启用条目 + Reference 引用 id，
   语义与 #201 现有实现一致）重复的 id。直连数据保留在 DataStore，用户可随时在「独立注入」中管理。
3. **`AssistantExtensionIds.kt`**：删除不再使用的 `withModeInjectionsDedupedAgainstPresets`；
   `boundPresetInjectionIds` 保留并补充用途说明（组装期过滤 + ExtensionSelector UI 共用）。
4. **测试**：
   - `ModeInjectionDirectBindingDedupeTest` 重写：`boundPresetInjectionIds` 纯语义
     （启用/禁用条目、Reference 双 id、旧字段、未绑定预设）+ 加载期
     `withPrunedAssistantExtensionIds` 保留双绑直连数据、仍丢弃无效 id。
   - `PromptInjectionTransformerTest` 新增组装期用例：双绑输出无重复注入、Reference entry.id 直连不双注入、
     禁用预设条目后直连恢复生效且无残留、`collectInjections` 不返回重复 id。

## 验收条件 | Acceptance criteria

- [ ] #204：记忆编辑/清理确认弹窗在横屏、大字体、长内容/候选 40+ 时内容可滚动，按钮始终可达。
- [ ] #205：双绑（preset entry + assistant 直连）时直连绑定在 DataStore 中保留、可在「独立注入」中看到并管理；
      组装输出不出现重复注入；关闭/禁用预设后直连按用户意图恢复生效，system 消息不残留旧注入（#201 行为不回归）。
- [ ] #201 既有行为保持：关闭预设/世界书/记忆后 system 消息无残留旧注入（现有 `PromptInjectionTransformerTest` 契约不回归）。

## UI 截图 / 录屏 | UI evidence

N/A（无本地设备/模拟器环境，未截图；UI 行为请用户真机验证）。

## 测试 | Testing

- 命令 / 检查：
  - 静态自查：全文件 grep 确认两个弹窗均有 `heightIn` + `verticalScroll`、按钮在滚动区外；
    `joinToString` 单 Text 堆叠已移除；`withModeInjectionsDedupedAgainstPresets` 无残留引用；
    `migratedPresets` 仍在使用；import 完整、无未使用变量（`horizontalScroll`/`LazyColumn`/`rememberScrollState` 等原有用法保留）；
    `git diff` 逐 hunk 复查；6 个改动文件括号配平校验通过。
  - 改动文件：6 个（3 主代码 + 2 测试 + 1 测试重写）。
- 结果：静态自查通过。
- **如实声明：本环境无本地 Java/Gradle，未编译、未运行单元测试；依赖 GitHub CI 与用户真机验证。**

## 数据兼容 | Data compatibility

- #205：不再在加载期删除 `assistant.modeInjectionIds` 直连绑定——v2.3.43 已被 #201 静默删除的数据无法恢复，
  但自本版本起双绑直连数据会保留在 DataStore；序列化格式无变化。
- #204：纯 UI 改动，无数据影响。

## 风险与回滚 | Risks and rollback

- 风险：组装期过滤为每轮发送新增一次 `boundPresetInjectionIds` 计算（预设列表小，开销可忽略）。
- 回滚：整体 revert 本 PR 即可回到 #201 的加载期删除语义（注意届时直连绑定仍会被删除）。

## 已知限制 | Known limitations

- #201 已删除的直连绑定无法自动恢复（历史数据已不可逆），需要用户重新勾选。
- 若 GitHub CI 单测发现行为回归，优先检查 `PromptInjectionTransformerTest` 的 preset 相关用例。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果（见上「测试」节）
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
