### PR TITLE
feat(#207): reasoning dialect mapping and per-model config

### DIFF
--- a/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
+++ b/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
@@ -30,3 +30,135 @@ enum class ReasoningLevel(
         }
     }
 }
+
+/**
+ * Wire vocabulary for reasoning effort tokens.
+ *
+ * [ReasoningLevel] is the user-facing abstract ladder (off…xhigh).
+ * [ReasoningDialect] decides how that ladder is encoded for a given model/provider
+ * (e.g. DeepSeek uses `max` instead of `xhigh`).
+ *
+ * Priority when resolving: per-model override → host rules → model-id hints → [OpenAIExtended].
+ */
+@Serializable
+enum class ReasoningDialect {
+    /** Follow host / model-id recognition. */
+    @SerialName("auto")
+    Auto,
+
+    /** `none|low|medium|high|xhigh` (OpenAI extended / OpenRouter-style). */
+    @SerialName("openai_extended")
+    OpenAIExtended,
+
+    /** No `xhigh`; top rung clamps to `high`. */
+    @SerialName("openai_classic")
+    OpenAIClassic,
+
+    /** DeepSeek-style vocabulary; top rung is `max` (official + many proxies). */
+    @SerialName("deepseek_max")
+    DeepSeekMax,
+
+    /** Provider only supports enable/disable; effort string is not sent. */
+    @SerialName("on_off_only")
+    OnOffOnly,
+}
+
+/**
+ * Resolves the effective dialect used when mapping [ReasoningLevel] to wire tokens.
+ *
+ * @param explicit value from [me.rerere.ai.provider.Model.reasoningDialect] (default [ReasoningDialect.Auto])
+ * @param host provider baseUrl host (e.g. `api.deepseek.com`)
+ * @param modelId raw model id string
+ */
+fun resolveDialect(
+    explicit: ReasoningDialect,
+    host: String,
+    modelId: String,
+): ReasoningDialect {
+    if (explicit != ReasoningDialect.Auto) return explicit
+
+    val id = modelId.lowercase()
+    return when {
+        host == "api.deepseek.com" -> ReasoningDialect.DeepSeekMax
+        host == "integrate.api.nvidia.com" && "deepseek-v4" in id -> ReasoningDialect.DeepSeekMax
+        // Weak hint for proxies whose host is not official DeepSeek.
+        looksLikeDeepSeekReasoningModel(id) -> ReasoningDialect.DeepSeekMax
+        else -> ReasoningDialect.OpenAIExtended
+    }
+}
+
+/**
+ * Maps an abstract [ReasoningLevel] to an OpenAI-style `reasoning_effort` / `effort` wire token.
+ *
+ * @return wire token, or `null` when the field should be omitted ([ReasoningLevel.AUTO],
+ *   or [ReasoningDialect.OnOffOnly] which only toggles enable/disable in the host branch).
+ * @param noneAsLow some Chat Completions defaults historically map OFF/`none` → `"low"`
+ *   because those models cannot fully disable reasoning via effort.
+ */
+fun mapReasoningEffort(
+    dialect: ReasoningDialect,
+    level: ReasoningLevel,
+    noneAsLow: Boolean = false,
+): String? {
+    if (level == ReasoningLevel.AUTO) return null
+    // Auto should already be resolved by resolveDialect; treat residual Auto as extended.
+    val effective = if (dialect == ReasoningDialect.Auto) {
+        ReasoningDialect.OpenAIExtended
+    } else {
+        dialect
+    }
+
+    return when (effective) {
+        ReasoningDialect.Auto,
+        ReasoningDialect.OpenAIExtended -> when {
+            level == ReasoningLevel.OFF && noneAsLow -> "low"
+            else -> level.effort
+        }
+
+        ReasoningDialect.OpenAIClassic -> when (level) {
+            ReasoningLevel.OFF -> if (noneAsLow) "low" else "none"
+            ReasoningLevel.LOW -> "low"
+            ReasoningLevel.MEDIUM -> "medium"
+            ReasoningLevel.HIGH,
+            ReasoningLevel.XHIGH -> "high"
+            ReasoningLevel.AUTO -> null
+        }
+
+        ReasoningDialect.DeepSeekMax -> when (level) {
+            ReasoningLevel.OFF -> if (noneAsLow) "low" else "none"
+            ReasoningLevel.LOW -> "low"
+            ReasoningLevel.MEDIUM -> "medium"
+            ReasoningLevel.HIGH -> "high"
+            ReasoningLevel.XHIGH -> "max"
+            ReasoningLevel.AUTO -> null
+        }
+
+        ReasoningDialect.OnOffOnly -> null
+    }
+}
+
+/**
+ * NVIDIA DeepSeek-V4 Chat Completions historically collapse non-off/non-xhigh levels to `high`.
+ * Keep that coarse table so existing nvidia behavior does not regress.
+ */
+fun mapNvidiaDeepSeekV4Effort(level: ReasoningLevel): String? {
+    if (level == ReasoningLevel.AUTO) return null
+    return when (level) {
+        ReasoningLevel.XHIGH -> "max"
+        ReasoningLevel.OFF -> "none"
+        else -> "high"
+    }
+}
+
+private fun looksLikeDeepSeekReasoningModel(modelIdLower: String): Boolean {
+    if (!modelIdLower.contains("deepseek")) return false
+    return modelIdLower.contains("reasoner") ||
+        modelIdLower.contains("r1") ||
+        modelIdLower.contains("v3.1") ||
+        modelIdLower.contains("v3_1") ||
+        modelIdLower.contains("v3-1") ||
+        modelIdLower.contains("v3.2") ||
+        modelIdLower.contains("v3_2") ||
+        modelIdLower.contains("v3-2") ||
+        modelIdLower.contains("v4")
+}

--- a/ai/src/main/java/me/rerere/ai/provider/Model.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/Model.kt
@@ -3,6 +3,7 @@ package me.rerere.ai.provider
 import androidx.compose.runtime.Immutable
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import me.rerere.ai.core.ReasoningDialect
 import kotlin.uuid.Uuid
 
 @Immutable
@@ -21,6 +22,13 @@ data class Model(
     val providerOverwrite: ProviderSetting? = null,
     /** Optional output dim for embedding APIs that support truncation (e.g. OpenAI `dimensions`). */
     val embeddingDimensions: Int? = null,
+    /**
+     * Per-model override for reasoning effort wire vocabulary (#207).
+     * Default [ReasoningDialect.Auto] follows host / model-id recognition so official
+     * DeepSeek works out of the box; set [ReasoningDialect.DeepSeekMax] explicitly for
+     * proxy / mid-station baseUrls whose host is not `api.deepseek.com`.
+     */
+    val reasoningDialect: ReasoningDialect = ReasoningDialect.Auto,
 )
 
 @Serializable

--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -639,29 +639,3 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         )
     }
 }
-veOrNull?.intOrNull ?: 0
-        val completionTokens = usageJson["output_tokens"]?.jsonPrimitive?.intOrNull ?: 0
-        val promptTokens = inputTokens + cachedInputTokens + cachedCreationTokens
-        return TokenUsage(
-            promptTokens = promptTokens,
-            completionTokens = completionTokens,
-            totalTokens = promptTokens + completionTokens,
-            cachedTokens = cachedInputTokens,
-        )
-    }
-}
-s = cachedInputTokens,
-        )
-    }
-}
-veOrNull?.intOrNull ?: 0
-        val completionTokens = usageJson["output_tokens"]?.jsonPrimitive?.intOrNull ?: 0
-        val promptTokens = inputTokens + cachedInputTokens + cachedCreationTokens
-        return TokenUsage(
-            promptTokens = promptTokens,
-            completionTokens = completionTokens,
-            totalTokens = promptTokens + completionTokens,
-            cachedTokens = cachedInputTokens,
-        )
-    }
-}

--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -28,6 +28,8 @@ import kotlinx.serialization.json.putJsonArray
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.core.mapReasoningEffort
+import me.rerere.ai.core.resolveDialect
 import me.rerere.ai.provider.ClaudePromptCacheTtl
 import me.rerere.ai.provider.ImageGenerationParams
 import me.rerere.ai.provider.Model
@@ -59,6 +61,7 @@ import me.rerere.common.http.asJsonObjectLenient
 import me.rerere.common.http.await
 import me.rerere.common.http.jsonObjectOrNull
 import me.rerere.common.http.jsonPrimitiveOrNull
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -351,9 +354,19 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                             put("type", "adaptive")
                             put("display", "summarized")
                         })
-                        put("output_config", buildJsonObject {
-                            put("effort", params.reasoningLevel.effort)
-                        })
+                        val host = runCatching {
+                            providerSetting.baseUrl.toHttpUrl().host
+                        }.getOrDefault("")
+                        val dialect = resolveDialect(
+                            explicit = params.model.reasoningDialect,
+                            host = host,
+                            modelId = params.model.modelId,
+                        )
+                        mapReasoningEffort(dialect, params.reasoningLevel)?.let { effort ->
+                            put("output_config", buildJsonObject {
+                                put("effort", effort)
+                            })
+                        }
                     }
                 }
             }
@@ -616,6 +629,32 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         val inputTokens = usageJson["input_tokens"]?.jsonPrimitive?.intOrNull ?: 0
         val cachedInputTokens = usageJson["cache_read_input_tokens"]?.jsonPrimitiveOrNull?.intOrNull ?: 0
         val cachedCreationTokens = usageJson["cache_creation_input_tokens"]?.jsonPrimitiveOrNull?.intOrNull ?: 0
+        val completionTokens = usageJson["output_tokens"]?.jsonPrimitive?.intOrNull ?: 0
+        val promptTokens = inputTokens + cachedInputTokens + cachedCreationTokens
+        return TokenUsage(
+            promptTokens = promptTokens,
+            completionTokens = completionTokens,
+            totalTokens = promptTokens + completionTokens,
+            cachedTokens = cachedInputTokens,
+        )
+    }
+}
+veOrNull?.intOrNull ?: 0
+        val completionTokens = usageJson["output_tokens"]?.jsonPrimitive?.intOrNull ?: 0
+        val promptTokens = inputTokens + cachedInputTokens + cachedCreationTokens
+        return TokenUsage(
+            promptTokens = promptTokens,
+            completionTokens = completionTokens,
+            totalTokens = promptTokens + completionTokens,
+            cachedTokens = cachedInputTokens,
+        )
+    }
+}
+s = cachedInputTokens,
+        )
+    }
+}
+veOrNull?.intOrNull ?: 0
         val completionTokens = usageJson["output_tokens"]?.jsonPrimitive?.intOrNull ?: 0
         val promptTokens = inputTokens + cachedInputTokens + cachedCreationTokens
         return TokenUsage(

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -28,6 +28,9 @@ import kotlinx.serialization.json.putJsonArray
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.core.mapNvidiaDeepSeekV4Effort
+import me.rerere.ai.core.mapReasoningEffort
+import me.rerere.ai.core.resolveDialect
 import me.rerere.ai.provider.Modality
 import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.ModelAbility
@@ -305,6 +308,11 @@ class ChatCompletionsAPI(
 
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
                 val level = params.reasoningLevel
+                val dialect = resolveDialect(
+                    explicit = params.model.reasoningDialect,
+                    host = host,
+                    modelId = params.model.modelId,
+                )
                 when (host) {
                     "openrouter.ai" -> {
                         // https://openrouter.ai/docs/use-cases/reasoning-tokens
@@ -312,7 +320,10 @@ class ChatCompletionsAPI(
                             when (level) {
                                 ReasoningLevel.OFF -> put("effort", "none")
                                 ReasoningLevel.AUTO -> put("enabled", true)
-                                else -> put("effort", level.effort)
+                                else -> {
+                                    val effort = mapReasoningEffort(dialect, level) ?: level.effort
+                                    put("effort", effort)
+                                }
                             }
                         })
                     }
@@ -402,38 +413,29 @@ class ChatCompletionsAPI(
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
                         if (level.isEnabled && level != ReasoningLevel.AUTO) {
-                            put("reasoning_effort", level.effort)
+                            mapReasoningEffort(dialect, level)?.let { put("reasoning_effort", it) }
                         }
                     }
 
                     "integrate.api.nvidia.com" -> {
                         if ("deepseek-v4" in params.model.modelId.lowercase()) {
-                            if (level != ReasoningLevel.AUTO) {
-                                val effort = when (level) {
-                                    ReasoningLevel.XHIGH -> "max"
-                                    ReasoningLevel.OFF -> "none"
-                                    else -> "high"
-                                }
-                                put("reasoning_effort", effort)
-                            }
+                            mapNvidiaDeepSeekV4Effort(level)?.let { put("reasoning_effort", it) }
                         } else {
-                            if (level != ReasoningLevel.AUTO) {
-                                put("reasoning_effort", if (level.effort == "none") "low" else level.effort)
+                            mapReasoningEffort(dialect, level, noneAsLow = true)?.let {
+                                put("reasoning_effort", it)
                             }
                         }
                     }
 
                     "opencode.ai" -> {
-                        if (level != ReasoningLevel.AUTO) {
-                            put("reasoning_effort", level.effort)
-                        }
+                        mapReasoningEffort(dialect, level)?.let { put("reasoning_effort", it) }
                     }
 
                     else -> {
-                        // OpenAI 官方
+                        // OpenAI 官方 / 通用 OpenAI-compat
                         // 文档中，completions API 只支持 "low", "medium", "high"
-                        if (level != ReasoningLevel.AUTO) {
-                            put("reasoning_effort", if (level.effort == "none") "low" else level.effort)
+                        mapReasoningEffort(dialect, level, noneAsLow = true)?.let {
+                            put("reasoning_effort", it)
                         }
                     }
                 }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -809,10 +809,3 @@ internal fun resolveResponseProviderCapabilities(host: String): ResponseProvider
     }
 }
 
-ent = false
-        )
-
-        else -> ResponseProviderCapabilities()
-    }
-}
-

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -23,6 +23,8 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
+import me.rerere.ai.core.mapReasoningEffort
+import me.rerere.ai.core.resolveDialect
 import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.provider.BuiltInTools
 import me.rerere.ai.provider.Model
@@ -232,13 +234,16 @@ class ResponseAPI(
             // reasoning
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
                 val level = params.reasoningLevel
+                val dialect = resolveDialect(
+                    explicit = params.model.reasoningDialect,
+                    host = host,
+                    modelId = params.model.modelId,
+                )
                 put("reasoning", buildJsonObject {
                     if (capabilities.supportsReasoningSummary) {
                         put("summary", "auto")
                     }
-                    if (level != ReasoningLevel.AUTO) {
-                        put("effort", level.effort)
-                    }
+                    mapReasoningEffort(dialect, level)?.let { put("effort", it) }
                 })
                 if (capabilities.supportEncryptedContent) {
                     put("include", buildJsonArray {
@@ -798,6 +803,13 @@ internal fun resolveResponseProviderCapabilities(host: String): ResponseProvider
         "ark.cn-beijing.volces.com" -> ResponseProviderCapabilities(
             supportsReasoningSummary = false,
             supportEncryptedContent = false
+        )
+
+        else -> ResponseProviderCapabilities()
+    }
+}
+
+ent = false
         )
 
         else -> ResponseProviderCapabilities()

--- a/ai/src/test/java/me/rerere/ai/core/ReasoningDialectTest.kt
+++ b/ai/src/test/java/me/rerere/ai/core/ReasoningDialectTest.kt
@@ -1,0 +1,136 @@
+package me.rerere.ai.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for reasoning dialect resolve/map (#207).
+ */
+class ReasoningDialectTest {
+
+    @Test
+    fun `explicit dialect wins over host and model id`() {
+        val dialect = resolveDialect(
+            explicit = ReasoningDialect.OpenAIClassic,
+            host = "api.deepseek.com",
+            modelId = "deepseek-reasoner",
+        )
+        assertEquals(ReasoningDialect.OpenAIClassic, dialect)
+    }
+
+    @Test
+    fun `auto resolves official deepseek host to DeepSeekMax`() {
+        val dialect = resolveDialect(
+            explicit = ReasoningDialect.Auto,
+            host = "api.deepseek.com",
+            modelId = "deepseek-chat",
+        )
+        assertEquals(ReasoningDialect.DeepSeekMax, dialect)
+    }
+
+    @Test
+    fun `auto resolves nvidia deepseek-v4 to DeepSeekMax`() {
+        val dialect = resolveDialect(
+            explicit = ReasoningDialect.Auto,
+            host = "integrate.api.nvidia.com",
+            modelId = "deepseek-ai/deepseek-v4-pro",
+        )
+        assertEquals(ReasoningDialect.DeepSeekMax, dialect)
+    }
+
+    @Test
+    fun `auto uses model-id hint for deepseek reasoner on unknown host`() {
+        val dialect = resolveDialect(
+            explicit = ReasoningDialect.Auto,
+            host = "proxy.example.com",
+            modelId = "deepseek-reasoner",
+        )
+        assertEquals(ReasoningDialect.DeepSeekMax, dialect)
+    }
+
+    @Test
+    fun `auto falls back to OpenAIExtended for unknown models`() {
+        val dialect = resolveDialect(
+            explicit = ReasoningDialect.Auto,
+            host = "api.openai.com",
+            modelId = "o3-mini",
+        )
+        assertEquals(ReasoningDialect.OpenAIExtended, dialect)
+    }
+
+    @Test
+    fun `DeepSeekMax maps XHIGH to max`() {
+        assertEquals(
+            "max",
+            mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.XHIGH),
+        )
+        assertEquals(
+            "high",
+            mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.HIGH),
+        )
+        assertEquals(
+            "none",
+            mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.OFF),
+        )
+    }
+
+    @Test
+    fun `OpenAIExtended keeps xhigh`() {
+        assertEquals(
+            "xhigh",
+            mapReasoningEffort(ReasoningDialect.OpenAIExtended, ReasoningLevel.XHIGH),
+        )
+    }
+
+    @Test
+    fun `OpenAIClassic clamps XHIGH to high`() {
+        assertEquals(
+            "high",
+            mapReasoningEffort(ReasoningDialect.OpenAIClassic, ReasoningLevel.XHIGH),
+        )
+    }
+
+    @Test
+    fun `noneAsLow rewrites OFF`() {
+        assertEquals(
+            "low",
+            mapReasoningEffort(
+                ReasoningDialect.OpenAIExtended,
+                ReasoningLevel.OFF,
+                noneAsLow = true,
+            ),
+        )
+        assertEquals(
+            "none",
+            mapReasoningEffort(
+                ReasoningDialect.OpenAIExtended,
+                ReasoningLevel.OFF,
+                noneAsLow = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `AUTO omits effort token`() {
+        assertNull(mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.AUTO))
+        assertNull(mapReasoningEffort(ReasoningDialect.OpenAIExtended, ReasoningLevel.AUTO))
+    }
+
+    @Test
+    fun `OnOffOnly never emits effort token`() {
+        assertNull(mapReasoningEffort(ReasoningDialect.OnOffOnly, ReasoningLevel.XHIGH))
+        assertNull(mapReasoningEffort(ReasoningDialect.OnOffOnly, ReasoningLevel.HIGH))
+        assertNull(mapReasoningEffort(ReasoningDialect.OnOffOnly, ReasoningLevel.OFF))
+    }
+
+    @Test
+    fun `nvidia deepseek-v4 coarse table`() {
+        assertEquals("max", mapNvidiaDeepSeekV4Effort(ReasoningLevel.XHIGH))
+        assertEquals("none", mapNvidiaDeepSeekV4Effort(ReasoningLevel.OFF))
+        assertEquals("high", mapNvidiaDeepSeekV4Effort(ReasoningLevel.LOW))
+        assertEquals("high", mapNvidiaDeepSeekV4Effort(ReasoningLevel.MEDIUM))
+        assertEquals("high", mapNvidiaDeepSeekV4Effort(ReasoningLevel.HIGH))
+        assertNull(mapNvidiaDeepSeekV4Effort(ReasoningLevel.AUTO))
+    }
+}

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIReasoningDialectTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIReasoningDialectTest.kt
@@ -1,0 +1,163 @@
+package me.rerere.ai.provider.providers.openai
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.core.ReasoningDialect
+import me.rerere.ai.core.ReasoningLevel
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.TextGenerationParams
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.util.KeyRoulette
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Chat Completions reasoning effort dialect mapping (#207):
+ * - official DeepSeek XHIGH → max
+ * - mid-station proxy + per-model DeepSeekMax
+ * - default OpenAI-compat none→low / xhigh passthrough
+ * - nvidia deepseek-v4 regression
+ */
+class ChatCompletionsAPIReasoningDialectTest {
+
+    private lateinit var api: ChatCompletionsAPI
+
+    @Before
+    fun setUp() {
+        api = ChatCompletionsAPI(OkHttpClient(), KeyRoulette.default())
+    }
+
+    private fun buildRequest(
+        baseUrl: String,
+        modelId: String,
+        reasoningLevel: ReasoningLevel,
+        reasoningDialect: ReasoningDialect = ReasoningDialect.Auto,
+    ): JsonObject {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "buildChatCompletionRequest",
+            List::class.java,
+            TextGenerationParams::class.java,
+            ProviderSetting.OpenAI::class.java,
+            Boolean::class.javaPrimitiveType,
+        )
+        method.isAccessible = true
+        val model = Model(
+            modelId = modelId,
+            abilities = listOf(ModelAbility.REASONING),
+            reasoningDialect = reasoningDialect,
+        )
+        val params = TextGenerationParams(
+            model = model,
+            reasoningLevel = reasoningLevel,
+        )
+        val providerSetting = ProviderSetting.OpenAI(baseUrl = baseUrl)
+        return method.invoke(
+            api,
+            listOf(UIMessage.user("hi")),
+            params,
+            providerSetting,
+            true,
+        ) as JsonObject
+    }
+
+    @Test
+    fun `official deepseek XHIGH sends reasoning_effort max`() {
+        val body = buildRequest(
+            baseUrl = "https://api.deepseek.com",
+            modelId = "deepseek-reasoner",
+            reasoningLevel = ReasoningLevel.XHIGH,
+        )
+        assertEquals("enabled", body["thinking"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
+        assertEquals("max", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `official deepseek HIGH keeps high`() {
+        val body = buildRequest(
+            baseUrl = "https://api.deepseek.com",
+            modelId = "deepseek-reasoner",
+            reasoningLevel = ReasoningLevel.HIGH,
+        )
+        assertEquals("high", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `official deepseek AUTO enables thinking without effort`() {
+        val body = buildRequest(
+            baseUrl = "https://api.deepseek.com",
+            modelId = "deepseek-reasoner",
+            reasoningLevel = ReasoningLevel.AUTO,
+        )
+        assertEquals("enabled", body["thinking"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
+        assertFalse(body.containsKey("reasoning_effort"))
+    }
+
+    @Test
+    fun `proxy host with explicit DeepSeekMax maps XHIGH to max`() {
+        val body = buildRequest(
+            baseUrl = "https://mid.station.example/v1",
+            modelId = "my-ds-alias",
+            reasoningLevel = ReasoningLevel.XHIGH,
+            reasoningDialect = ReasoningDialect.DeepSeekMax,
+        )
+        assertEquals("max", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `proxy host Auto without deepseek id keeps xhigh`() {
+        val body = buildRequest(
+            baseUrl = "https://mid.station.example/v1",
+            modelId = "gpt-whatever",
+            reasoningLevel = ReasoningLevel.XHIGH,
+        )
+        assertEquals("xhigh", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `default openai-compat OFF maps none to low`() {
+        val body = buildRequest(
+            baseUrl = "https://api.openai.com/v1",
+            modelId = "o3-mini",
+            reasoningLevel = ReasoningLevel.OFF,
+        )
+        assertEquals("low", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `nvidia deepseek-v4 XHIGH still max`() {
+        val body = buildRequest(
+            baseUrl = "https://integrate.api.nvidia.com/v1",
+            modelId = "deepseek-ai/deepseek-v4-pro",
+            reasoningLevel = ReasoningLevel.XHIGH,
+        )
+        assertEquals("max", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `nvidia deepseek-v4 LOW still high coarse table`() {
+        val body = buildRequest(
+            baseUrl = "https://integrate.api.nvidia.com/v1",
+            modelId = "deepseek-ai/deepseek-v4-flash",
+            reasoningLevel = ReasoningLevel.LOW,
+        )
+        assertEquals("high", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `moonshot on-off shape unchanged`() {
+        val body = buildRequest(
+            baseUrl = "https://api.moonshot.cn/v1",
+            modelId = "kimi-k2.5",
+            reasoningLevel = ReasoningLevel.HIGH,
+        )
+        assertEquals("enabled", body["thinking"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
+        assertNull(body["reasoning_effort"])
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -311,6 +311,7 @@ fun ChatInput(
                                         onUpdateAssistant(assistant.copy(reasoningLevel = it))
                                     },
                                     onlyIcon = true,
+                                    dialect = model.reasoningDialect,
                                 )
                             }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ReasoningPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ReasoningPicker.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import me.rerere.ai.core.ReasoningDialect
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Idea
@@ -46,8 +47,15 @@ import me.rerere.rikkahub.ui.components.ui.icons.ReasoningLow
 import me.rerere.rikkahub.ui.components.ui.icons.ReasoningMedium
 import kotlin.math.roundToInt
 
-private val levels = ReasoningLevel.entries
-private val levelCount = levels.size
+private val allLevels = ReasoningLevel.entries
+
+private fun levelsForDialect(dialect: ReasoningDialect): List<ReasoningLevel> {
+    return if (dialect == ReasoningDialect.OnOffOnly) {
+        listOf(ReasoningLevel.OFF, ReasoningLevel.AUTO)
+    } else {
+        allLevels
+    }
+}
 
 @Composable
 fun ReasoningButton(
@@ -55,6 +63,7 @@ fun ReasoningButton(
     onlyIcon: Boolean = false,
     reasoningLevel: ReasoningLevel,
     onUpdateReasoningLevel: (ReasoningLevel) -> Unit,
+    dialect: ReasoningDialect = ReasoningDialect.Auto,
 ) {
     var showPicker by remember { mutableStateOf(false) }
 
@@ -62,7 +71,8 @@ fun ReasoningButton(
         ReasoningPicker(
             reasoningLevel = reasoningLevel,
             onDismissRequest = { showPicker = false },
-            onUpdateReasoningLevel = onUpdateReasoningLevel
+            onUpdateReasoningLevel = onUpdateReasoningLevel,
+            dialect = dialect,
         )
     }
 
@@ -92,11 +102,21 @@ fun ReasoningPicker(
     reasoningLevel: ReasoningLevel,
     onDismissRequest: () -> Unit = {},
     onUpdateReasoningLevel: (ReasoningLevel) -> Unit,
+    dialect: ReasoningDialect = ReasoningDialect.Auto,
 ) {
-    val currentIndex = levels.indexOf(reasoningLevel).coerceAtLeast(0)
-    var sliderValue by remember { mutableFloatStateOf(currentIndex.toFloat()) }
+    val levels = remember(dialect) { levelsForDialect(dialect) }
+    val levelCount = levels.size
+    val effectiveLevel = if (reasoningLevel in levels) {
+        reasoningLevel
+    } else if (reasoningLevel.isEnabled) {
+        ReasoningLevel.AUTO
+    } else {
+        ReasoningLevel.OFF
+    }
+    val currentIndex = levels.indexOf(effectiveLevel).coerceAtLeast(0)
+    var sliderValue by remember(dialect) { mutableFloatStateOf(currentIndex.toFloat()) }
 
-    LaunchedEffect(currentIndex) {
+    LaunchedEffect(currentIndex, dialect) {
         sliderValue = currentIndex.toFloat()
     }
 
@@ -135,11 +155,11 @@ fun ReasoningPicker(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 val iconColor by animateColorAsState(
-                    if (reasoningLevel.isEnabled) MaterialTheme.colorScheme.primary
+                    if (effectiveLevel.isEnabled) MaterialTheme.colorScheme.primary
                     else MaterialTheme.colorScheme.onSurface
                 )
                 Icon(
-                    imageVector = when (reasoningLevel) {
+                    imageVector = when (effectiveLevel) {
                         ReasoningLevel.OFF -> HugeIcons.Idea
                         ReasoningLevel.AUTO -> HugeIcons.Idea01
                         ReasoningLevel.LOW -> ReasoningLow
@@ -152,7 +172,7 @@ fun ReasoningPicker(
                     tint = iconColor,
                 )
                 Text(
-                    text = reasoningLevel.label(),
+                    text = effectiveLevel.label(),
                     style = MaterialTheme.typography.titleMedium,
                 )
             }
@@ -198,7 +218,8 @@ fun ReasoningPicker(
                 )
 
                 ReasoningScale(
-                    selectedLevel = reasoningLevel,
+                    levels = levels,
+                    selectedLevel = effectiveLevel,
                     onSelect = { level ->
                         sliderValue = levels.indexOf(level).toFloat()
                         onUpdateReasoningLevel(level)
@@ -211,6 +232,7 @@ fun ReasoningPicker(
 
 @Composable
 private fun ReasoningScale(
+    levels: List<ReasoningLevel>,
     selectedLevel: ReasoningLevel,
     onSelect: (ReasoningLevel) -> Unit,
 ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
@@ -93,6 +93,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dokar.sonner.ToastType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import me.rerere.ai.core.ReasoningDialect
 import me.rerere.ai.provider.BuiltInTools
 import me.rerere.ai.provider.Modality
 import me.rerere.ai.provider.Model
@@ -720,6 +721,14 @@ private fun ModelSettingsForm(
                                     onModelChange(model.copy(abilities = it))
                                 }
                             )
+                            if (ModelAbility.REASONING in model.abilities) {
+                                ReasoningDialectSelector(
+                                    selected = model.reasoningDialect,
+                                    onSelected = {
+                                        onModelChange(model.copy(reasoningDialect = it))
+                                    },
+                                )
+                            }
                         }
 
                         if (model.type == ModelType.EMBEDDING) {
@@ -1272,6 +1281,58 @@ fun ModalAbilitySelector(
                     )
                 }
             )
+        }
+    }
+}
+
+/**
+ * Per-model reasoning effort vocabulary (#207).
+ * Shown only when REASONING ability is enabled — mid-station DeepSeek etc. can pin DeepSeekMax.
+ */
+@Composable
+private fun ReasoningDialectSelector(
+    selected: ReasoningDialect,
+    onSelected: (ReasoningDialect) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            stringResource(R.string.setting_provider_page_reasoning_dialect),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+            stringResource(R.string.setting_provider_page_reasoning_dialect_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            ReasoningDialect.entries.forEach { dialect ->
+                InputChip(
+                    selected = selected == dialect,
+                    onClick = { onSelected(dialect) },
+                    label = {
+                        Text(
+                            text = stringResource(
+                                when (dialect) {
+                                    ReasoningDialect.Auto ->
+                                        R.string.setting_provider_page_reasoning_dialect_auto
+                                    ReasoningDialect.OpenAIExtended ->
+                                        R.string.setting_provider_page_reasoning_dialect_openai_extended
+                                    ReasoningDialect.OpenAIClassic ->
+                                        R.string.setting_provider_page_reasoning_dialect_openai_classic
+                                    ReasoningDialect.DeepSeekMax ->
+                                        R.string.setting_provider_page_reasoning_dialect_deepseek_max
+                                    ReasoningDialect.OnOffOnly ->
+                                        R.string.setting_provider_page_reasoning_dialect_on_off
+                                }
+                            )
+                        )
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -803,7 +803,7 @@
   <string name="reasoning_medium_desc">模型将使用更多推理来回答问题。</string>
   <string name="reasoning_off">关闭</string>
   <string name="reasoning_off_desc">关闭推理功能，模型将直接回答问题。</string>
-  <string name="reasoning_picker_hint">并非所有模型都支持深度调整。请参考模型和提供商文档。</string>
+  <string name="reasoning_picker_hint">并非所有模型都支持深度调整。「超高」表示该模型允许的最高思考强度（DeepSeek 会映射为 max）。中转站请在模型设置中配置思考强度方言。请参考提供商文档。</string>
   <string name="reasoning_picker_title">调整模型思考深度</string>
   <string name="reasoning_xhigh">超高</string>
   <string name="regenerate">重新生成</string>
@@ -1196,6 +1196,13 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="setting_provider_page_embedding_dimensions">向量维度</string>
   <string name="setting_provider_page_embedding_dimensions_desc">可选。在 API 支持时请求截断/降维输出（如 OpenAI dimensions）。留空则使用完整维度。</string>
   <string name="setting_provider_page_embedding_model">嵌入</string>
+  <string name="setting_provider_page_reasoning_dialect">思考强度方言</string>
+  <string name="setting_provider_page_reasoning_dialect_desc">将抽象思考档位（低…超高）映射为服务商实际参数。中转站 DeepSeek 若报 xhigh 非法，请选「DeepSeek（最高 max）」。自动：按域名/模型 ID 识别。</string>
+  <string name="setting_provider_page_reasoning_dialect_auto">自动</string>
+  <string name="setting_provider_page_reasoning_dialect_openai_extended">OpenAI 扩展（含 xhigh）</string>
+  <string name="setting_provider_page_reasoning_dialect_openai_classic">OpenAI 经典（最高 high）</string>
+  <string name="setting_provider_page_reasoning_dialect_deepseek_max">DeepSeek（最高 max）</string>
+  <string name="setting_provider_page_reasoning_dialect_on_off">仅开关</string>
   <string name="setting_provider_page_enable">是否启用</string>
   <string name="setting_provider_page_enabled">启用</string>
   <string name="setting_provider_page_filter_example">例如：GPT-3.5</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -837,7 +837,7 @@
   <string name="reasoning_medium_desc">The model will use more reasoning to answer questions.</string>
   <string name="reasoning_off">Off</string>
   <string name="reasoning_off_desc">Turn off reasoning functionality, the model will directly answer questions.</string>
-  <string name="reasoning_picker_hint">Not all models support depth adjustment. Refer to the model and provider documentation.</string>
+  <string name="reasoning_picker_hint">Not all models support depth adjustment. XHigh means the highest strength the model allows (e.g. max on DeepSeek). Set the reasoning dialect in model settings for mid-station proxies. Refer to provider docs.</string>
   <string name="reasoning_picker_title">Adjust Model Thinking Depth</string>
   <string name="reasoning_xhigh">XHigh</string>
   <string name="regenerate">Regenerate</string>
@@ -1245,6 +1245,13 @@
   <string name="setting_provider_page_embedding_dimensions">Embedding dimensions</string>
   <string name="setting_provider_page_embedding_dimensions_desc">Optional. Truncates / requests reduced vector size when the API supports it (e.g. OpenAI dimensions). Leave empty for full size.</string>
   <string name="setting_provider_page_embedding_model">Embedding</string>
+  <string name="setting_provider_page_reasoning_dialect">Reasoning effort dialect</string>
+  <string name="setting_provider_page_reasoning_dialect_desc">Maps abstract thinking depth (Low…XHigh) to the provider\'s wire values. Use DeepSeek (max) for official DeepSeek or mid-station proxies that reject xhigh. Auto follows host / model id.</string>
+  <string name="setting_provider_page_reasoning_dialect_auto">Auto</string>
+  <string name="setting_provider_page_reasoning_dialect_openai_extended">OpenAI extended (xhigh)</string>
+  <string name="setting_provider_page_reasoning_dialect_openai_classic">OpenAI classic (high)</string>
+  <string name="setting_provider_page_reasoning_dialect_deepseek_max">DeepSeek (max)</string>
+  <string name="setting_provider_page_reasoning_dialect_on_off">On / off only</string>
   <string name="setting_provider_page_enable">Enable</string>
   <string name="setting_provider_page_enabled">Enabled</string>
   <string name="setting_provider_page_filter_example">e.g.: GPT-3.5</string>


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #207

## 变更说明 | Changes

拆分「抽象思考强度」与「wire 词汇」：

- 新增 `ReasoningDialect`（Auto / OpenAIExtended / OpenAIClassic / DeepSeekMax / OnOffOnly）
- 中央 `resolveDialect` + `mapReasoningEffort`（+ NVIDIA DeepSeek-V4 粗表 `mapNvidiaDeepSeekV4Effort`）
- `Model.reasoningDialect` 默认 `Auto`，模型个例设置可覆盖（中转站主路径）
- `ChatCompletionsAPI` / `ResponseAPI` / `ClaudeProvider` 将 effort 字符串迁入方言映射；moonshot/dashscope/siliconflow 等 on-off / budget 形状保持不变
- 模型设置页方言 chips；`ReasoningPicker` 在 OnOffOnly 时收敛为 OFF + AUTO
- Chat 输入栏把当前模型 `reasoningDialect` 传给 picker

**不**暴露「发 xhigh 还是 max」用户选项；**不**新增 `ReasoningLevel.MAX`。

相关：#1195 / #1532 / #1573

## 验收条件 | Acceptance criteria

- [x] AC1: `api.deepseek.com` Auto + XHIGH → `reasoning_effort=max`（单测覆盖）
- [x] AC2: 自定义中转 baseUrl + 个例 `DeepSeekMax` → XHIGH→`max`（单测覆盖）
- [x] AC3: `Model.reasoningDialect` 默认 Auto；旧数据缺省兼容
- [x] AC4: NVIDIA DeepSeek-V4 粗表、Moonshot on/off 形状保留（单测 + 代码路径）
- [x] AC5: UI 无 xhigh/max 二选一；抽象档位 + 模型方言配置
- [x] AC6: `ReasoningDialectTest` + `ChatCompletionsAPIReasoningDialectTest`
- [x] AC7: 未知 host + 未知模型 + Auto 仍透传 xhigh（单测）
- [x] AC8: App picker 仍按 REASONING 能力门控；OnOffOnly 收敛
- [x] AC9: 字段进 Model 序列化（DataStore/备份随设置走）
- [x] AC10: OnOffOnly 下 picker 仅 OFF + AUTO

## UI 截图 / 录屏 | UI evidence

模型个例设置：REASONING 能力开启时出现「思考强度方言」chips（自动 / OpenAI 扩展 / OpenAI 经典 / DeepSeek max / 仅开关）。

Chat 输入栏既有 ReasoningButton；OnOffOnly 时 sheet 只显示关闭/自动。无「xhigh vs max」用户开关。

（本环境无真机截图；请验收时补）

## 测试 | Testing

- 命令：`./gradlew :ai:testDebugUnitTest --tests 'me.rerere.ai.core.ReasoningDialectTest' --tests 'me.rerere.ai.provider.providers.openai.ChatCompletionsAPIReasoningDialectTest' --tests 'me.rerere.ai.provider.providers.openai.ChatCompletionsAPIMoonshotTest'`
- 结果：**未执行** — 工作区无 JDK（`JAVA_HOME` 未设置，`java` 不在 PATH）。请 CI / 本地补跑。
- 代码审查：provider 映射接线、默认 Auto、moonshot/nvidia 分支形状已人工核对。

## 数据兼容 | Data compatibility

- 新增 `Model.reasoningDialect`，序列化默认 `Auto`
- 旧备份/设置缺省字段 → Auto，行为与改造前透传兼容
- 无 DB migration；助手仍只存 `ReasoningLevel`

## 风险与回滚 | Risks and rollback

- **风险**：中转站 Auto 且 model id 不含 deepseek 系 hint 时，仍可能发 `xhigh` → 400；需用户在模型设置选 DeepSeek（max）。文案已提示。
- **回滚**：revert 本 PR；字段默认 Auto 对旧逻辑友好。

## 已知限制 | Known limitations

- Kimi K3 完整 dialect 挂接 follow-up 见 #1573
- Web `reasoning-picker` 未在本 PR 同步（若存在独立 web-ui 路径需 follow-up）
- 本环境未跑单元测试 / 真机构建

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [ ] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」