### PR TITLE
fix(#202,#203,#206): semantic memory config write, cancellation, export

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -755,6 +755,24 @@ class SettingsStore(
         return updated
     }
 
+    /**
+     * Atomically applies a mutation to the latest persisted semantic memory config
+     * without rewriting unrelated settings (#202). Mirrors [updatePreset].
+     */
+    suspend fun updateSemanticMemoryConfig(
+        transform: (me.rerere.rikkahub.data.memory.semantic.SemanticMemoryConfig) -> me.rerere.rikkahub.data.memory.semantic.SemanticMemoryConfig,
+    ) {
+        val fallbackSettings = settingsFlow.value
+        dataStore.edit { preferences ->
+            val current = preferences[SEMANTIC_MEMORY_CONFIG]?.let {
+                runCatching {
+                    JsonInstant.decodeFromString<me.rerere.rikkahub.data.memory.semantic.SemanticMemoryConfig>(it)
+                }.getOrNull()
+            } ?: fallbackSettings.semanticMemoryConfig
+            preferences[SEMANTIC_MEMORY_CONFIG] = JsonInstant.encodeToString(transform(current))
+        }
+    }
+
     suspend fun updateAssistantWorkspaceBinding(
         assistantId: Uuid,
         workspaceId: Uuid?,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemorySettingPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemorySettingPage.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -42,7 +43,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Brain02
 import me.rerere.rikkahub.Screen
-import me.rerere.rikkahub.data.memory.semantic.SemanticMemoryConfig
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
 import me.rerere.rikkahub.ui.context.LocalNavController
@@ -63,22 +63,19 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
     val testResult by vm.testResult.collectAsStateWithLifecycle()
     val isProcessing by vm.isProcessing.collectAsStateWithLifecycle()
     val message by vm.message.collectAsStateWithLifecycle()
+    val exportResult by vm.exportResult.collectAsStateWithLifecycle()
     val stats by vm.stats.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val navController = LocalNavController.current
 
-    var pendingExportUri by remember { mutableStateOf<Uri?>(null) }
     var showImportConfirm by remember { mutableStateOf(false) }
     var pendingImportPath by remember { mutableStateOf<String?>(null) }
+    var exportNotice by remember { mutableStateOf<String?>(null) }
 
     val exportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/gzip")
     ) { uri: Uri? ->
-        uri?.let {
-            pendingExportUri = it
-            val cacheFile = java.io.File(context.cacheDir, "semantic_memory_export.gz")
-            vm.exportData(cacheFile.absolutePath)
-        }
+        uri?.let { vm.exportData(it) }
     }
 
     val importLauncher = rememberLauncherForActivityResult(
@@ -149,7 +146,7 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                         trailingContent = {
                             Switch(
                                 checked = config.enabled,
-                                onCheckedChange = { vm.updateConfig(config.copy(enabled = it)) },
+                                onCheckedChange = { newValue -> vm.updateConfig { it.copy(enabled = newValue) } },
                             )
                         }
                     )
@@ -186,11 +183,11 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                                 allowClear = true,
                                 onSelect = { model ->
                                     // ModelSelector clear calls onSelect(Model()) with blank modelId
-                                    vm.updateConfig(
-                                        config.copy(
+                                    vm.updateConfig {
+                                        it.copy(
                                             embeddingModelId = model.id.takeUnless { model.modelId.isBlank() },
-                                        ),
-                                    )
+                                        )
+                                    }
                                 },
                             )
                             Button(
@@ -224,12 +221,22 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                 ) {
                     item {
                         Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                            // 数字输入局部缓冲: 只更新本地文本, 失焦时解析并提交 (避免每次按键全量写)
+                            var topKText by remember(config.topK) { mutableStateOf(config.topK.toString()) }
                             OutlinedTextField(
-                                value = config.topK.toString(),
-                                onValueChange = { v -> v.toIntOrNull()?.let { vm.updateConfig(config.copy(topK = it.coerceIn(1, 100))) } },
+                                value = topKText,
+                                onValueChange = { topKText = it },
                                 label = { Text("每次召回最大记忆条数 (1-100)") },
                                 keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            topKText.toIntOrNull()?.let { parsed ->
+                                                vm.updateConfig { it.copy(topK = parsed.coerceIn(1, 100)) }
+                                            }
+                                        }
+                                    },
                                 singleLine = true,
                             )
                             Text(
@@ -237,66 +244,83 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                                 style = MaterialTheme.typography.bodySmall,
                                 modifier = Modifier.padding(top = 8.dp),
                             )
+                            // Slider: 拖动只更新本地缓冲, 松手时才持久化 (#202)
+                            var localThreshold by remember(config.similarityThreshold) { mutableStateOf(config.similarityThreshold) }
                             Slider(
-                                value = config.similarityThreshold,
-                                onValueChange = { vm.updateConfig(config.copy(similarityThreshold = it)) },
+                                value = localThreshold,
+                                onValueChange = { localThreshold = it },
+                                onValueChangeFinished = {
+                                    vm.updateConfig { it.copy(similarityThreshold = localThreshold) }
+                                },
                                 valueRange = 0f..1f,
                             )
+                            var maxCoreInjectText by remember(config.maxCoreInject) { mutableStateOf(config.maxCoreInject?.toString().orEmpty()) }
                             OutlinedTextField(
-                                value = config.maxCoreInject?.toString().orEmpty(),
-                                onValueChange = { v ->
-                                    if (v.isBlank()) {
-                                        vm.updateConfig(config.copy(maxCoreInject = null))
-                                    } else {
-                                        v.toIntOrNull()?.let {
-                                            vm.updateConfig(config.copy(maxCoreInject = it.takeIf { n -> n > 0 }))
-                                        }
-                                    }
-                                },
+                                value = maxCoreInjectText,
+                                onValueChange = { maxCoreInjectText = it },
                                 label = { Text("注入核心记忆上限") },
                                 supportingText = { Text("空 = 不限制；注入 system 时最多带入多少条 core") },
                                 keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 8.dp),
+                                    .padding(top = 8.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            if (maxCoreInjectText.isBlank()) {
+                                                vm.updateConfig { it.copy(maxCoreInject = null) }
+                                            } else {
+                                                maxCoreInjectText.toIntOrNull()?.let { parsed ->
+                                                    vm.updateConfig { it.copy(maxCoreInject = parsed.takeIf { n -> n > 0 }) }
+                                                }
+                                            }
+                                        }
+                                    },
                                 singleLine = true,
                             )
+                            var maxInjectCharsText by remember(config.maxInjectChars) { mutableStateOf(config.maxInjectChars?.toString().orEmpty()) }
                             OutlinedTextField(
-                                value = config.maxInjectChars?.toString().orEmpty(),
-                                onValueChange = { v ->
-                                    if (v.isBlank()) {
-                                        vm.updateConfig(config.copy(maxInjectChars = null))
-                                    } else {
-                                        v.toIntOrNull()?.let {
-                                            vm.updateConfig(config.copy(maxInjectChars = it.takeIf { n -> n > 0 }))
-                                        }
-                                    }
-                                },
+                                value = maxInjectCharsText,
+                                onValueChange = { maxInjectCharsText = it },
                                 label = { Text("注入总字符预算") },
                                 supportingText = { Text("空 = 不限制；记忆正文总长度上限") },
                                 keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 8.dp),
+                                    .padding(top = 8.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            if (maxInjectCharsText.isBlank()) {
+                                                vm.updateConfig { it.copy(maxInjectChars = null) }
+                                            } else {
+                                                maxInjectCharsText.toIntOrNull()?.let { parsed ->
+                                                    vm.updateConfig { it.copy(maxInjectChars = parsed.takeIf { n -> n > 0 }) }
+                                                }
+                                            }
+                                        }
+                                    },
                                 singleLine = true,
                             )
+                            var maxMemoryContentLenText by remember(config.maxMemoryContentLen) { mutableStateOf(config.maxMemoryContentLen?.toString().orEmpty()) }
                             OutlinedTextField(
-                                value = config.maxMemoryContentLen?.toString().orEmpty(),
-                                onValueChange = { v ->
-                                    if (v.isBlank()) {
-                                        vm.updateConfig(config.copy(maxMemoryContentLen = null))
-                                    } else {
-                                        v.toIntOrNull()?.let {
-                                            vm.updateConfig(config.copy(maxMemoryContentLen = it.takeIf { n -> n > 0 }))
-                                        }
-                                    }
-                                },
+                                value = maxMemoryContentLenText,
+                                onValueChange = { maxMemoryContentLenText = it },
                                 label = { Text("单条记忆内容上限") },
                                 supportingText = { Text("空 = 不截断；sanitize 后单条最长字符") },
                                 keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number),
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 8.dp),
+                                    .padding(top = 8.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            if (maxMemoryContentLenText.isBlank()) {
+                                                vm.updateConfig { it.copy(maxMemoryContentLen = null) }
+                                            } else {
+                                                maxMemoryContentLenText.toIntOrNull()?.let { parsed ->
+                                                    vm.updateConfig { it.copy(maxMemoryContentLen = parsed.takeIf { n -> n > 0 }) }
+                                                }
+                                            }
+                                        }
+                                    },
                                 singleLine = true,
                             )
                         }
@@ -307,7 +331,7 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                         trailingContent = {
                             Switch(
                                 checked = config.enableFallbackKeyword,
-                                onCheckedChange = { vm.updateConfig(config.copy(enableFallbackKeyword = it)) },
+                                onCheckedChange = { newValue -> vm.updateConfig { it.copy(enableFallbackKeyword = newValue) } },
                             )
                         }
                     )
@@ -355,62 +379,78 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                                 Text("自动总结", style = MaterialTheme.typography.bodyMedium)
                                 Switch(
                                     checked = config.autoSummarizeEnabled,
-                                    onCheckedChange = { vm.updateConfig(config.copy(autoSummarizeEnabled = it)) },
+                                    onCheckedChange = { newValue -> vm.updateConfig { it.copy(autoSummarizeEnabled = newValue) } },
                                 )
                             }
+                            var summarizeIntervalText by remember(config.summarizeInterval) { mutableStateOf(config.summarizeInterval.toString()) }
                             OutlinedTextField(
-                                value = config.summarizeInterval.toString(),
-                                onValueChange = {
-                                    it.toIntOrNull()?.let { v ->
-                                        vm.updateConfig(config.copy(summarizeInterval = v.coerceAtLeast(1)))
-                                    }
-                                },
+                                value = summarizeIntervalText,
+                                onValueChange = { summarizeIntervalText = it },
                                 label = { Text("总结间隔 (对话轮数)") },
                                 supportingText = { Text("每 N 轮用户消息自动触发一次总结") },
                                 singleLine = true,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 8.dp),
+                                    .padding(top = 8.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            summarizeIntervalText.toIntOrNull()?.let { parsed ->
+                                                vm.updateConfig { it.copy(summarizeInterval = parsed.coerceAtLeast(1)) }
+                                            }
+                                        }
+                                    },
                             )
+                            var autoSummarizeMessageCountText by remember(config.autoSummarizeMessageCount) { mutableStateOf(config.autoSummarizeMessageCount.toString()) }
                             OutlinedTextField(
-                                value = config.autoSummarizeMessageCount.toString(),
-                                onValueChange = {
-                                    it.toIntOrNull()?.let { v ->
-                                        vm.updateConfig(config.copy(autoSummarizeMessageCount = v.coerceIn(4, 100)))
-                                    }
-                                },
+                                value = autoSummarizeMessageCountText,
+                                onValueChange = { autoSummarizeMessageCountText = it },
                                 label = { Text("自动总结取最近消息条数 (4-100)") },
                                 supportingText = { Text("自动总结时从最新消息往上取多少条对话") },
                                 singleLine = true,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 8.dp),
+                                    .padding(top = 8.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            autoSummarizeMessageCountText.toIntOrNull()?.let { parsed ->
+                                                vm.updateConfig { it.copy(autoSummarizeMessageCount = parsed.coerceIn(4, 100)) }
+                                            }
+                                        }
+                                    },
                             )
+                            var maxMemoriesPerSummaryText by remember(config.maxMemoriesPerSummary) { mutableStateOf(config.maxMemoriesPerSummary.toString()) }
                             OutlinedTextField(
-                                value = config.maxMemoriesPerSummary.toString(),
-                                onValueChange = {
-                                    it.toIntOrNull()?.let { v ->
-                                        vm.updateConfig(config.copy(maxMemoriesPerSummary = v.coerceAtLeast(1)))
-                                    }
-                                },
+                                value = maxMemoriesPerSummaryText,
+                                onValueChange = { maxMemoriesPerSummaryText = it },
                                 label = { Text("每次总结最多提取记忆数") },
                                 singleLine = true,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 8.dp),
+                                    .padding(top = 8.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            maxMemoriesPerSummaryText.toIntOrNull()?.let { parsed ->
+                                                vm.updateConfig { it.copy(maxMemoriesPerSummary = parsed.coerceAtLeast(1)) }
+                                            }
+                                        }
+                                    },
                             )
+                            var maxMemoriesPerAssistantText by remember(config.maxMemoriesPerAssistant) { mutableStateOf(config.maxMemoriesPerAssistant.toString()) }
                             OutlinedTextField(
-                                value = config.maxMemoriesPerAssistant.toString(),
-                                onValueChange = {
-                                    it.toIntOrNull()?.let { v ->
-                                        vm.updateConfig(config.copy(maxMemoriesPerAssistant = v.coerceAtLeast(100)))
-                                    }
-                                },
+                                value = maxMemoriesPerAssistantText,
+                                onValueChange = { maxMemoriesPerAssistantText = it },
                                 label = { Text("每个助手最大记忆数") },
                                 singleLine = true,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 8.dp),
+                                    .padding(top = 8.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            maxMemoriesPerAssistantText.toIntOrNull()?.let { parsed ->
+                                                vm.updateConfig { it.copy(maxMemoriesPerAssistant = parsed.coerceAtLeast(100)) }
+                                            }
+                                        }
+                                    },
                             )
                             // 总结用模型选择
                             Text(
@@ -425,7 +465,7 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                                 providers = settings.providers,
                                 type = me.rerere.ai.provider.ModelType.CHAT,
                                 allowClear = true,
-                                onSelect = { vm.updateConfig(config.copy(summarizeModelId = it.id)) },
+                                onSelect = { model -> vm.updateConfig { it.copy(summarizeModelId = model.id) } },
                             )
                             // 提示词编辑器
                             Text(
@@ -435,17 +475,19 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                                     .fillMaxWidth()
                                     .padding(top = 12.dp),
                             )
-                            var promptText by remember { mutableStateOf(config.summarizePrompt ?: "") }
+                            var promptText by remember(config.summarizePrompt) { mutableStateOf(config.summarizePrompt ?: "") }
                             OutlinedTextField(
                                 value = promptText,
-                                onValueChange = {
-                                    promptText = it
-                                    vm.updateConfig(config.copy(summarizePrompt = it.ifBlank { null }))
-                                },
+                                onValueChange = { promptText = it },
                                 placeholder = { Text(me.rerere.rikkahub.data.memory.semantic.MemorySummarizer.DEFAULT_PROMPT.take(100) + "...", style = MaterialTheme.typography.bodySmall) },
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(top = 4.dp),
+                                    .padding(top = 4.dp)
+                                    .onFocusChanged { focusState ->
+                                        if (!focusState.isFocused) {
+                                            vm.updateConfig { it.copy(summarizePrompt = promptText.ifBlank { null }) }
+                                        }
+                                    },
                                 minLines = 3,
                                 maxLines = 8,
                             )
@@ -456,7 +498,7 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                                 OutlinedButton(
                                     onClick = {
                                         promptText = me.rerere.rikkahub.data.memory.semantic.MemorySummarizer.DEFAULT_PROMPT
-                                        vm.updateConfig(config.copy(summarizePrompt = promptText))
+                                        vm.updateConfig { it.copy(summarizePrompt = promptText) }
                                     },
                                 ) {
                                     Text("载入默认")
@@ -464,7 +506,7 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                                 OutlinedButton(
                                     onClick = {
                                         promptText = ""
-                                        vm.updateConfig(config.copy(summarizePrompt = null))
+                                        vm.updateConfig { it.copy(summarizePrompt = null) }
                                     },
                                 ) {
                                     Text("恢复默认")
@@ -478,7 +520,7 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                         trailingContent = {
                             Switch(
                                 checked = config.autoEvictionEnabled,
-                                onCheckedChange = { vm.updateConfig(config.copy(autoEvictionEnabled = it)) },
+                                onCheckedChange = { newValue -> vm.updateConfig { it.copy(autoEvictionEnabled = newValue) } },
                             )
                         }
                     )
@@ -597,10 +639,32 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
                     }
                 }
             }
+
+            // 导出结果提示 (#206): 由 VM 的 exportResult 事件驱动, 不复用 message/魔数
+            exportNotice?.let { notice ->
+                item("exportNotice") {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                    ) {
+                        Text(
+                            text = notice,
+                            modifier = Modifier.padding(16.dp),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = if (exportResult?.success == true) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.error
+                            },
+                        )
+                    }
+                }
+            }
         }
     }
 
-    // 自动清除消息
+    // 自动清除消息 (仅作用于提示文案, 与导出任务解耦)
     if (message != null) {
         androidx.compose.runtime.LaunchedEffect(message) {
             kotlinx.coroutines.delay(3000)
@@ -608,19 +672,10 @@ fun SemanticMemorySettingPage(vm: SemanticMemoryVM = koinViewModel()) {
         }
     }
 
-    // 导出完成后, 将缓存文件复制到用户选择的 URI (VM 消息为 "Export OK")
-    LaunchedEffect(message) {
-        if (message == "Export OK") {
-            pendingExportUri?.let { uri ->
-                val cacheFile = java.io.File(context.cacheDir, "semantic_memory_export.gz")
-                if (cacheFile.exists() && cacheFile.length() > 0) {
-                    context.contentResolver.openOutputStream(uri)?.use { output ->
-                        cacheFile.inputStream().use { input -> input.copyTo(output) }
-                    }
-                }
-                cacheFile.delete()
-                pendingExportUri = null
-            }
+    // 导出完成事件 (#206): 只消费 VM 的 exportResult 并展示, 不再依赖 "Export OK" 魔数
+    LaunchedEffect(exportResult) {
+        exportResult?.let { res ->
+            exportNotice = res.message
         }
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemoryVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemoryVM.kt
@@ -1,9 +1,13 @@
 // [SemanticMemory Plugin]
 package me.rerere.rikkahub.ui.pages.setting
 
+import android.content.Context
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -12,6 +16,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.db.entity.EpisodicMemoryEntity
@@ -28,6 +33,12 @@ import kotlin.uuid.Uuid
 
 private const val TAG = "SemanticMemoryVM"
 
+/** Result of an export operation, surfaced via [SemanticMemoryVM.exportResult]. */
+data class ExportResult(
+    val success: Boolean,
+    val message: String,
+)
+
 class SemanticMemoryVM(
     private val settingsStore: SettingsStore,
     private val embeddingService: EmbeddingService,
@@ -35,6 +46,7 @@ class SemanticMemoryVM(
     private val repository: SemanticMemoryRepository,
     private val recallService: RecallService,
     private val conversationRepository: ConversationRepository,
+    private val context: Context,
 ) : ViewModel() {
 
     val settings: StateFlow<Settings> = settingsStore.settingsFlow
@@ -51,6 +63,9 @@ class SemanticMemoryVM(
 
     private val _message = MutableStateFlow<String?>(null)
     val message: StateFlow<String?> = _message
+
+    private val _exportResult = MutableStateFlow<ExportResult?>(null)
+    val exportResult: StateFlow<ExportResult?> = _exportResult
 
     private val _lastSummarizeDetail = MutableStateFlow<SummarizeResult?>(null)
     val lastSummarizeDetail: StateFlow<SummarizeResult?> = _lastSummarizeDetail
@@ -74,11 +89,11 @@ class SemanticMemoryVM(
         _selectedAssistantId.value = assistantId
     }
 
-    fun updateConfig(config: SemanticMemoryConfig) {
+    fun updateConfig(transform: (SemanticMemoryConfig) -> SemanticMemoryConfig) {
         viewModelScope.launch {
             val current = settings.value
             if (current.init) return@launch
-            settingsStore.update(current.copy(semanticMemoryConfig = config))
+            settingsStore.updateSemanticMemoryConfig(transform)
         }
     }
 
@@ -96,15 +111,26 @@ class SemanticMemoryVM(
         }
     }
 
-    fun exportData(filePath: String) {
+    fun exportData(targetUri: Uri) {
         viewModelScope.launch {
             _isProcessing.value = true
             _message.value = null
+            _exportResult.value = null
             runCatching {
-                semanticMemoryManager.exportToFile(filePath)
-                _message.value = "Export OK"
+                val cacheFile = java.io.File(context.cacheDir, "semantic_memory_export.gz")
+                semanticMemoryManager.exportToFile(cacheFile.absolutePath)
+                // Copy the cache file to the user-selected destination URI (blocking I/O → IO dispatcher).
+                withContext(Dispatchers.IO) {
+                    context.contentResolver.openOutputStream(targetUri)?.use { output ->
+                        cacheFile.inputStream().use { input -> input.copyTo(output) }
+                    } ?: error("无法打开目标文件")
+                }
+                cacheFile.delete()
             }.onFailure {
-                _message.value = "Export failed: ${it.message}"
+                if (it is CancellationException) throw it
+                _exportResult.value = ExportResult(false, "Export failed: ${it.message}")
+            }.onSuccess {
+                _exportResult.value = ExportResult(true, "导出成功")
             }
             _isProcessing.value = false
         }
@@ -118,6 +144,7 @@ class SemanticMemoryVM(
                 val count = semanticMemoryManager.importFromFile(filePath)
                 _message.value = "Imported $count memories"
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Import failed: ${it.message}"
             }
             _isProcessing.value = false
@@ -132,6 +159,7 @@ class SemanticMemoryVM(
                 val count = semanticMemoryManager.migrateAllOldMemories()
                 _message.value = if (count > 0) "Migrated $count memories" else "No old memories"
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Migrate failed: ${it.message}"
             }
             _isProcessing.value = false
@@ -176,6 +204,7 @@ class SemanticMemoryVM(
                     }
                 }
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Summarize failed: ${it.message}"
                 Log.e(TAG, "triggerSummarize failed", it)
             }
@@ -213,6 +242,7 @@ class SemanticMemoryVM(
                     }
                 }
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Recall test failed: ${it.message}"
             }
             _isProcessing.value = false
@@ -252,6 +282,7 @@ class SemanticMemoryVM(
                     "Memory added"
                 }
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Add failed: ${it.message}"
             }
             _isProcessing.value = false
@@ -288,6 +319,7 @@ class SemanticMemoryVM(
                 repository.updateMemory(updated)
                 recallService.invalidateCache(memory.assistantId)
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Update failed: ${it.message}"
             }
             _isProcessing.value = false
@@ -301,6 +333,7 @@ class SemanticMemoryVM(
                 recallService.invalidateCache(assistantId)
                 _message.value = "Memory deleted"
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Delete failed: ${it.message}"
             }
         }
@@ -320,6 +353,7 @@ class SemanticMemoryVM(
                 _evictionCandidates.value = emptyList()
                 _message.value = "Evicted ${ids.size} memories"
             }.onFailure {
+                if (it is CancellationException) throw it
                 _message.value = "Eviction failed: ${it.message}"
             }
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsVM.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.ui.pages.stats
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -162,7 +163,8 @@ class StatsVM(
                     apiHealthTimeRange = timeRange,
                     apiHealth = apiHealth,
                 )
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 _stats.value = _stats.value.copy(
                     isLoading = false,
                     isRefreshing = false,
@@ -193,7 +195,8 @@ class StatsVM(
                 apiHealth = apiHealth,
                 apiHealthDetail = detail,
             )
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
             _stats.value = _stats.value.copy(
                 isRefreshing = false,
                 loadError = true,


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #202
Closes #203
Closes #206

## 变更说明 | Changes

三个语义记忆相关 Bug 修复：

### #202 — 语义记忆设置页控件每次交互触发 DataStore 全量覆盖写，拖动/连点丢更新

- `app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt`：新增 `SettingsStore.updateSemanticMemoryConfig(transform)`，参照 `updatePreset` 的 `dataStore.edit` read-modify-write 范式做**原子写**（只读写 `SEMANTIC_MEMORY_CONFIG` 一个键，不触碰其他设置），修复「读 StateFlow 快照 → 全量覆盖写」导致的并发丢更新。
- `app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemoryVM.kt`：`updateConfig` 签名由 `(SemanticMemoryConfig)` 改为 `updateConfig(transform: (SemanticMemoryConfig) -> SemanticMemoryConfig)`，内部调用 `settingsStore.updateSemanticMemoryConfig(transform)`（保留 init 护栏）。
- `app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemorySettingPage.kt`：全部 21 处控件改为传 transform lambda；**相似度阈值 Slider** 拖动只更新本地缓冲、`onValueChangeFinished` 才持久化；**8 个数字/文本输入框**（topK、maxCoreInject、maxInjectChars、maxMemoryContentLen、summarizeInterval、autoSummarizeMessageCount、maxMemoriesPerSummary、maxMemoriesPerAssistant、summarizePrompt）本地字符串缓冲 + `onFocusChanged` 失焦提交，解析失败保持旧值。

### #203 — 吞掉 CancellationException 破坏结构化取消

- `app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SemanticMemoryVM.kt`：9 处 `runCatching`（exportData/importData/migrateAllOldMemories/triggerSummarize/testRecall/addMemory/updateMemory/deleteMemory/confirmEviction）的 `onFailure` 首行增加 `if (it is CancellationException) throw it`，其余错误处理副作用不变。
- `app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsVM.kt`：`loadStats` 与 `loadApiHealthOnly` 两处 `catch (_: Exception)` 改为捕获具名异常并在首行 rethrow `CancellationException`。

### #206 — 导出用字符串事件传结果，3s 自动清除中断复制致文件残缺

- `SemanticMemoryVM.kt`：新增顶层 `data class ExportResult(success, message)` 与 `exportResult: StateFlow<ExportResult?>` 事件流；`exportData` 改为 `exportData(targetUri: android.net.Uri)`，在 VM 内（`viewModelScope`）导出到 cache 后 `withContext(Dispatchers.IO)` 用 `ContentResolver.openOutputStream` 复制到用户 URI，成功/失败写回 `exportResult`；移除 `"Export OK"` 魔数字符串路径。
- `SemanticMemorySettingPage.kt`：导出按钮回调直接 `vm.exportData(uri)`；删除旧 `LaunchedEffect(message) { if (message == "Export OK") { 复制 } }`；新增 `LaunchedEffect(exportResult)` 只消费展示导出结果（页面 `exportNotice` 卡片，成功主色/失败错误色）；message 3s 自动清除仅作用于提示文案，不再与导出任务共享 key。

## 验收条件 | Acceptance criteria

- [ ] 语义记忆设置页快速拖动相似度阈值滑块/连点开关后，配置最终值正确持久化（无丢更新）
- [ ] 数字/文本输入失焦后配置才生效，非法输入不写坏配置
- [ ] 取消协程（页面销毁等）不再被吞，不产生竞态误写
- [ ] 导出记忆到用户所选 URI 完整生成 gzip 文件；复制期间页面提示不因 3s 自动清除而中断

## UI 截图 / 录屏 | UI evidence

N/A（行为修复，无界面布局变化）

## 测试 | Testing

- 命令 / 检查：静态自查（grep 确认无残留 `vm.updateConfig(config.copy(`、无 `"Export OK"` 魔数、`runCatching`/`catch` 均 rethrow CancellationException；git diff 逐 hunk 复查）
- 结果：**无本地 Gradle，未编译未跑单测，依赖 GitHub CI 与用户真机验证**

## 数据兼容 | Data compatibility

无数据库迁移；`SEMANTIC_MEMORY_CONFIG` 键格式不变（仍为 JsonInstant 序列化）；配置字段无增删改。

## 风险与回滚 | Risks and rollback

- 输入框由「每次按键写入」改为「失焦提交」：若用户输入后不离开焦点直接退出页面，改动不持久化（与预设页 DraftContextSection 既有范式一致）
- 回滚：`git revert` 即可，无迁移数据

## 已知限制 | Known limitations

- 数字输入失焦时解析失败保持旧值（静默）
- 无法在本地验证编译，需依赖 CI

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
