### PR TITLE
fix(#214): OFF 档不再发送 low；Auto 方言 deepseek 识别仅限官方 host

### DIFF
--- a/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
+++ b/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
@@ -38,11 +38,13 @@ enum class ReasoningLevel(
  * [ReasoningDialect] decides how that ladder is encoded for a given model/provider
  * (e.g. DeepSeek uses `max` instead of `xhigh`).
  *
- * Priority when resolving: per-model override → host rules → model-id hints → [OpenAIExtended].
+ * Priority when resolving: per-model override → official-host rules → [OpenAIExtended].
+ * Unknown hosts (custom proxies) stay on [OpenAIExtended] passthrough; users opt into a
+ * dialect explicitly via the per-model override.
  */
 @Serializable
 enum class ReasoningDialect {
-    /** Follow host / model-id recognition. */
+    /** Resolve from official host rules; unknown hosts default to [OpenAIExtended]. */
     @SerialName("auto")
     Auto,
 
@@ -81,8 +83,8 @@ fun resolveDialect(
     return when {
         host == "api.deepseek.com" -> ReasoningDialect.DeepSeekMax
         host == "integrate.api.nvidia.com" && "deepseek-v4" in id -> ReasoningDialect.DeepSeekMax
-        // Weak hint for proxies whose host is not official DeepSeek.
-        looksLikeDeepSeekReasoningModel(id) -> ReasoningDialect.DeepSeekMax
+        // Unknown hosts (custom proxies) keep OpenAI-compat passthrough of level.effort;
+        // users opt into DeepSeekMax explicitly via the per-model dialect override (#214).
         else -> ReasoningDialect.OpenAIExtended
     }
 }
@@ -92,13 +94,10 @@ fun resolveDialect(
  *
  * @return wire token, or `null` when the field should be omitted ([ReasoningLevel.AUTO],
  *   or [ReasoningDialect.OnOffOnly] which only toggles enable/disable in the host branch).
- * @param noneAsLow some Chat Completions defaults historically map OFF/`none` → `"low"`
- *   because those models cannot fully disable reasoning via effort.
  */
 fun mapReasoningEffort(
     dialect: ReasoningDialect,
     level: ReasoningLevel,
-    noneAsLow: Boolean = false,
 ): String? {
     if (level == ReasoningLevel.AUTO) return null
     // Auto should already be resolved by resolveDialect; treat residual Auto as extended.
@@ -110,13 +109,10 @@ fun mapReasoningEffort(
 
     return when (effective) {
         ReasoningDialect.Auto,
-        ReasoningDialect.OpenAIExtended -> when {
-            level == ReasoningLevel.OFF && noneAsLow -> "low"
-            else -> level.effort
-        }
+        ReasoningDialect.OpenAIExtended -> level.effort
 
         ReasoningDialect.OpenAIClassic -> when (level) {
-            ReasoningLevel.OFF -> if (noneAsLow) "low" else "none"
+            ReasoningLevel.OFF -> "none"
             ReasoningLevel.LOW -> "low"
             ReasoningLevel.MEDIUM -> "medium"
             ReasoningLevel.HIGH,
@@ -125,7 +121,7 @@ fun mapReasoningEffort(
         }
 
         ReasoningDialect.DeepSeekMax -> when (level) {
-            ReasoningLevel.OFF -> if (noneAsLow) "low" else "none"
+            ReasoningLevel.OFF -> "none"
             ReasoningLevel.LOW -> "low"
             ReasoningLevel.MEDIUM -> "medium"
             ReasoningLevel.HIGH -> "high"
@@ -148,17 +144,4 @@ fun mapNvidiaDeepSeekV4Effort(level: ReasoningLevel): String? {
         ReasoningLevel.OFF -> "none"
         else -> "high"
     }
-}
-
-private fun looksLikeDeepSeekReasoningModel(modelIdLower: String): Boolean {
-    if (!modelIdLower.contains("deepseek")) return false
-    return modelIdLower.contains("reasoner") ||
-        modelIdLower.contains("r1") ||
-        modelIdLower.contains("v3.1") ||
-        modelIdLower.contains("v3_1") ||
-        modelIdLower.contains("v3-1") ||
-        modelIdLower.contains("v3.2") ||
-        modelIdLower.contains("v3_2") ||
-        modelIdLower.contains("v3-2") ||
-        modelIdLower.contains("v4")
 }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -422,7 +422,7 @@ class ChatCompletionsAPI(
                         if ("deepseek-v4" in params.model.modelId.lowercase()) {
                             mapNvidiaDeepSeekV4Effort(level)?.let { put("reasoning_effort", it) }
                         } else {
-                            mapReasoningEffort(dialect, level, noneAsLow = true)?.let {
+                            mapReasoningEffort(dialect, level)?.let {
                                 put("reasoning_effort", it)
                             }
                         }
@@ -435,7 +435,7 @@ class ChatCompletionsAPI(
                     else -> {
                         // OpenAI 官方 / 通用 OpenAI-compat
                         // 文档中，completions API 只支持 "low", "medium", "high"
-                        mapReasoningEffort(dialect, level, noneAsLow = true)?.let {
+                        mapReasoningEffort(dialect, level)?.let {
                             put("reasoning_effort", it)
                         }
                     }

--- a/ai/src/test/java/me/rerere/ai/core/ReasoningDialectTest.kt
+++ b/ai/src/test/java/me/rerere/ai/core/ReasoningDialectTest.kt
@@ -40,13 +40,15 @@ class ReasoningDialectTest {
     }
 
     @Test
-    fun `auto uses model-id hint for deepseek reasoner on unknown host`() {
+    fun `auto keeps passthrough for deepseek id on unknown host`() {
+        // #214: weak model-id hints must not override unknown (proxy) hosts; users
+        // opt into DeepSeekMax explicitly via the per-model dialect override.
         val dialect = resolveDialect(
             explicit = ReasoningDialect.Auto,
             host = "proxy.example.com",
             modelId = "deepseek-reasoner",
         )
-        assertEquals(ReasoningDialect.DeepSeekMax, dialect)
+        assertEquals(ReasoningDialect.OpenAIExtended, dialect)
     }
 
     @Test
@@ -92,22 +94,18 @@ class ReasoningDialectTest {
     }
 
     @Test
-    fun `noneAsLow rewrites OFF`() {
+    fun `OFF maps to none never low`() {
         assertEquals(
-            "low",
-            mapReasoningEffort(
-                ReasoningDialect.OpenAIExtended,
-                ReasoningLevel.OFF,
-                noneAsLow = true,
-            ),
+            "none",
+            mapReasoningEffort(ReasoningDialect.OpenAIExtended, ReasoningLevel.OFF),
         )
         assertEquals(
             "none",
-            mapReasoningEffort(
-                ReasoningDialect.OpenAIExtended,
-                ReasoningLevel.OFF,
-                noneAsLow = false,
-            ),
+            mapReasoningEffort(ReasoningDialect.OpenAIClassic, ReasoningLevel.OFF),
+        )
+        assertEquals(
+            "none",
+            mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.OFF),
         )
     }
 

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIReasoningDialectTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIReasoningDialectTest.kt
@@ -22,7 +22,8 @@ import org.junit.Test
  * Chat Completions reasoning effort dialect mapping (#207):
  * - official DeepSeek XHIGH → max
  * - mid-station proxy + per-model DeepSeekMax
- * - default OpenAI-compat none→low / xhigh passthrough
+ * - default OpenAI-compat OFF→none / xhigh passthrough (#214)
+ * - unknown hosts keep passthrough for deepseek model ids (#214)
  * - nvidia deepseek-v4 regression
  */
 class ChatCompletionsAPIReasoningDialectTest {
@@ -121,13 +122,34 @@ class ChatCompletionsAPIReasoningDialectTest {
     }
 
     @Test
-    fun `default openai-compat OFF maps none to low`() {
+    fun `proxy host Auto with deepseek id keeps xhigh passthrough`() {
+        // #214: weak model-id hints must not force DeepSeekMax on unknown hosts.
+        val body = buildRequest(
+            baseUrl = "https://mid.station.example/v1",
+            modelId = "deepseek-reasoner",
+            reasoningLevel = ReasoningLevel.XHIGH,
+        )
+        assertEquals("xhigh", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `proxy host Auto OFF maps to none not low`() {
+        val body = buildRequest(
+            baseUrl = "https://mid.station.example/v1",
+            modelId = "deepseek-reasoner",
+            reasoningLevel = ReasoningLevel.OFF,
+        )
+        assertEquals("none", body["reasoning_effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `default openai-compat OFF maps to none not low`() {
         val body = buildRequest(
             baseUrl = "https://api.openai.com/v1",
             modelId = "o3-mini",
             reasoningLevel = ReasoningLevel.OFF,
         )
-        assertEquals("low", body["reasoning_effort"]?.jsonPrimitive?.content)
+        assertEquals("none", body["reasoning_effort"]?.jsonPrimitive?.content)
     }
 
     @Test


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #214

## 变更说明 | Changes

修复 #207（PR #210）思考等级方言映射遗留的两个问题：

1. **OFF 档不再发送 `reasoning_effort: "low"`**
   - `mapReasoningEffort` 移除 `noneAsLow` 参数（其唯一作用就是把 OFF 改写为 `"low"`，与「关闭思考」语义相悖）；OFF 在所有方言下统一映射为 `"none"`（OpenAIExtended/OpenAIClassic/DeepSeekMax）。
   - 该参数语义废弃后，`ChatCompletionsAPI` 中 nvidia 非 v4 分支与通用 OpenAI-compat 分支的两处 `noneAsLow = true` 调用一并清除。

2. **Auto 方言的 deepseek 自动识别仅限官方 host**
   - `resolveDialect` 删除弱提示 `looksLikeDeepSeekReasoningModel(id)`（连同私有函数）；Auto 仅在 `api.deepseek.com` 与 `integrate.api.nvidia.com`（+ deepseek-v4 id）解析为 `DeepSeekMax`。
   - 未知 host（自定义中转站）未配置模型个例方言时保持 OpenAI-compat 透传 `level.effort`（XHIGH → `"xhigh"`），由用户在模型设置显式选择 DeepSeek(max) 方言。

## 验收条件 | Acceptance criteria

- [x] 中转站 + Auto + deepseek 系 id（reasoner/r1/v3.x/v4）+ XHIGH：请求体 `reasoning_effort` 为 `"xhigh"`（透传），不再被强套为 `"max"`
- [x] 任意 host + OFF：请求体不再出现 `reasoning_effort: "low"`，统一为 `"none"`
- [x] 官方 host（api.deepseek.com）XHIGH → `"max"` 行为不变；nvidia deepseek-v4 粗粒度表不变
- [x] 显式配置 DeepSeekMax 方言仍覆盖 Auto（优先于 host 规则）

## UI 截图 / 录屏 | UI evidence

N/A（纯请求序列化逻辑，无 UI 变更）

## 测试 | Testing

- 命令 / 检查：`ai` 模块单测（`ReasoningDialectTest`、`ChatCompletionsAPIReasoningDialectTest`、`ResponseAPIMessageTest`）
- 结果：本环境无 Java/Gradle，未本地运行；已按仓库现有测试风格补齐/更新断言，交由 GitHub CI 验证
- 测试改动：
  - 新增 `proxy host Auto with deepseek id keeps xhigh passthrough`（补 issue 指出的测试缺口）
  - 新增 `proxy host Auto OFF maps to none not low`（OFF 档不发送 low）
  - 更新 `default openai-compat OFF maps to none not low`（原断言 `low` 改为 `none`）
  - `ReasoningDialectTest`：未知 host + deepseek id 期望由 `DeepSeekMax` 改为 `OpenAIExtended`；`noneAsLow rewrites OFF` 改为 `OFF maps to none never low`

## 数据兼容 | Data compatibility

N/A（无持久化结构变更；`reasoningDialect` 字段语义不变，仅 Auto 解析结果变化）

## 风险与回滚 | Risks and rollback

- 行为变化点：OpenAI-compat 中转站 OFF 档由发送 `"low"` 改为 `"none"`；若个别中转站拒绝 `"none"` 值可能报 400（与 openrouter/nvidia v4/opencode 既有 OFF 行为一致，属预期风险）。
- 回滚：`git revert` 本 PR 即可恢复 `noneAsLow` 与 model-id hint 行为。

## 已知限制 | Known limitations

- 未本地编译/跑测试（无 Java/Gradle 环境），依赖 GitHub CI。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
