### PR TITLE
fix(#222): add @Serializable to SettingClash screen

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -849,6 +849,7 @@ sealed interface Screen : NavKey {
 
     @Serializable
     data object SettingWeb : Screen
+    @Serializable
     data object SettingClash : Screen
 
     @Serializable


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #222

## 变更说明 | Changes

问题背景：进入 Clash 外部控制设置页（`Screen.SettingClash`）后，在 `onSaveInstanceState`（切后台/旋转/进程回收）时崩溃，抛 `kotlinx.serialization.SerializationException: Serializer for class 'Screen$SettingClash' is not found`。根因是 Navigation 3 的 `NavBackStackSerializer` 保存导航栈时需要路由的序列化器，而 `RouteActivity.kt` 中的 `data object SettingClash : Screen` 缺少 `@Serializable` 注解（同文件其他所有 Screen 均有）。

实现方案：在 `RouteActivity.kt` 的 `data object SettingClash : Screen` 前补上 `@Serializable` 注解，与相邻 Screen 定义格式一致。

## 验收条件 | Acceptance criteria

- [ ] 进入 Clash 外部控制设置页后，切后台/旋转/进程回收不再崩溃（保存导航栈正常）
- [ ] 导航栈恢复后仍停留在 Clash 设置页

## UI 截图 / 录屏 | UI evidence

N/A（无 UI 变更，仅补注解）

## 测试 | Testing

- 命令 / 检查：本修复为单行加注解的最小改动，未运行本地构建/编译/真机验证（当前环境无 Java/Gradle，构建与验证需 CI 或用户 PC 执行）
- 结果：未执行

## 数据兼容 | Data compatibility

N/A（无数据层变更）

## 风险与回滚 | Risks and rollback

风险极低：仅新增一个注解，不改动任何逻辑。回滚：`git revert` 该提交即可。

## 已知限制 | Known limitations

N/A

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」