### PR TITLE
fix(#226): stop variable macro engine spinning on unknown ST macros

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/variables/ConversationVariables.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/variables/ConversationVariables.kt
@@ -7,7 +7,13 @@ package me.rerere.rikkahub.data.ai.variables
 object ConversationVariables {
     const val MAX_VARIABLE_COUNT = 200
     const val MAX_VALUE_LENGTH = 32_000
+    /** Nested [expandMacros] recursion depth (e.g. setvar value containing macros). */
     const val MAX_MACRO_DEPTH = 20
+    /**
+     * Full-text expansion budget: how many macros may be replaced in one top-level pass.
+     * Separate from [MAX_MACRO_DEPTH] so large presets (50–200+ setvar/getvar) all expand (#226).
+     */
+    const val MAX_MACRO_EXPANSIONS = 2000
 
     fun truncateValue(value: String): String =
         if (value.length <= MAX_VALUE_LENGTH) value else value.take(MAX_VALUE_LENGTH)
@@ -61,6 +67,9 @@ object ConversationVariables {
      * - getvar → value or ""
      * - getglobalvar → "" (MVP; full global store is out of scope)
      * - setvar/addvar → mutate [variables] and remove the macro from text
+     * - `{{//...}}` ST comments → deleted
+     * - `{{newline}}` → "\n"; `{{trim}}` → "" (MVP: remove macro so it does not block later ones)
+     * - Unknown macros left as-is without burning the expansion budget (#226)
      */
     fun expandMacros(
         text: String,
@@ -71,26 +80,35 @@ object ConversationVariables {
         if (!text.contains("{{")) return text
 
         var result = text
-        var guard = 0
-        while (guard < MAX_MACRO_DEPTH) {
-            val innermost = findInnermostMacro(result) ?: break
+        var searchFrom = 0
+        var expansions = 0
+        while (expansions < MAX_MACRO_EXPANSIONS) {
+            val innermost = findInnermostMacro(result, searchFrom) ?: break
             val (range, body) = innermost
             val replacement = evaluateMacroBody(body, variables, depth)
+            // Unchanged unknown/passthrough macros must not re-hit forever (#226).
+            if (replacement == "{{$body}}") {
+                searchFrom = range.last + 1
+                continue
+            }
             result = result.replaceRange(range, replacement)
-            guard++
+            // Real change: re-scan left-to-right so new/shifted macros (incl. nested) resolve.
+            searchFrom = 0
+            expansions++
         }
         return result
     }
 
     /**
-     * Find the leftmost non-nested `{{...}}` pair (body contains no `{{`).
-     * Nested outers are skipped until their inner leaves are resolved (inner-first);
-     * sibling macros then expand left-to-right so setvar runs before a later getvar.
+     * Find the leftmost non-nested `{{...}}` pair at or after [searchFrom]
+     * (body contains no `{{`). Nested outers are skipped until their inner leaves
+     * are resolved (inner-first); sibling macros then expand left-to-right so
+     * setvar runs before a later getvar.
      */
-    private fun findInnermostMacro(text: String): Pair<IntRange, String>? {
-        var searchFrom = 0
-        while (searchFrom < text.length - 1) {
-            val start = text.indexOf("{{", searchFrom)
+    private fun findInnermostMacro(text: String, searchFrom: Int = 0): Pair<IntRange, String>? {
+        var from = searchFrom.coerceAtLeast(0)
+        while (from < text.length - 1) {
+            val start = text.indexOf("{{", from)
             if (start < 0) break
             val close = text.indexOf("}}", startIndex = start + 2)
             if (close < 0) break
@@ -98,7 +116,7 @@ object ConversationVariables {
             if (!body.contains("{{")) {
                 return (start..close + 1) to body
             }
-            searchFrom = start + 2
+            from = start + 2
         }
         return null
     }
@@ -111,6 +129,11 @@ object ConversationVariables {
         val trimmed = body.trim()
         val lower = trimmed.lowercase()
         return when {
+            // ST comment: {{// ...}} — delete so it never blocks later macros (#226)
+            trimmed.startsWith("//") -> ""
+            // Common ST whitespace helpers (MVP)
+            lower == "newline" -> "\n"
+            lower == "trim" -> ""
             lower.startsWith("getvar::") -> {
                 val name = trimmed.substringAfter("::").trim()
                 variables[name].orEmpty()
@@ -137,7 +160,8 @@ object ConversationVariables {
                 addVar(variables, name, resolved)
                 ""
             }
-            else -> "{{$body}}" // unknown macro: leave as-is for PlaceholderTransformer etc.
+            // Unknown macro: leave as-is for PlaceholderTransformer etc. (#226 skips re-scan)
+            else -> "{{$body}}"
         }
     }
 }

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/VariableMacroTransformerTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/VariableMacroTransformerTest.kt
@@ -82,4 +82,70 @@ class VariableMacroTransformerTest {
         assertTrue("overflow" !in vars)
         assertEquals(ConversationVariables.MAX_VARIABLE_COUNT, vars.size)
     }
+
+    @Test
+    fun `ST comment prefix does not block setvar getvar`() {
+        val vars = mutableMapOf<String, String>()
+        val out = ConversationVariables.expandMacros(
+            "{{// comment}}{{setvar::foo::bar}}value={{getvar::foo}}",
+            vars,
+        )
+        assertEquals("value=bar", out)
+        assertEquals("bar", vars["foo"])
+        assertTrue("//" !in out)
+        assertTrue("comment" !in out)
+    }
+
+    @Test
+    fun `multiline ST comment is deleted and following macros expand`() {
+        val vars = mutableMapOf<String, String>()
+        val out = ConversationVariables.expandMacros(
+            "{{//\npreset comment\n}}\n{{setvar::foo::bar}}value={{getvar::foo}}",
+            vars,
+        )
+        assertEquals("\nvalue=bar", out)
+        assertEquals("bar", vars["foo"])
+    }
+
+    @Test
+    fun `many sequential setvars all apply beyond former depth budget`() {
+        val count = 100
+        val sb = StringBuilder()
+        repeat(count) { i ->
+            sb.append("{{setvar::k$i::v$i}}")
+        }
+        sb.append("last={{getvar::k99}}")
+        val vars = mutableMapOf<String, String>()
+        val out = ConversationVariables.expandMacros(sb.toString(), vars)
+        assertEquals("last=v99", out)
+        assertEquals(count, vars.size)
+        assertEquals("v0", vars["k0"])
+        assertEquals("v50", vars["k50"])
+        assertEquals("v99", vars["k99"])
+    }
+
+    @Test
+    fun `trim does not block following getvar`() {
+        val vars = mutableMapOf("x" to "ok")
+        val out = ConversationVariables.expandMacros("{{trim}}{{getvar::x}}{{trim}}", vars)
+        assertEquals("ok", out)
+    }
+
+    @Test
+    fun `newline expands to line break`() {
+        val vars = mutableMapOf<String, String>()
+        val out = ConversationVariables.expandMacros("a{{newline}}b", vars)
+        assertEquals("a\nb", out)
+    }
+
+    @Test
+    fun `unknown macros are left intact without blocking later macros`() {
+        val vars = mutableMapOf<String, String>()
+        val out = ConversationVariables.expandMacros(
+            "{{char}}{{setvar::n::1}}={{getvar::n}}",
+            vars,
+        )
+        assertEquals("{{char}}=1", out)
+        assertEquals("1", vars["n"])
+    }
 }


### PR DESCRIPTION
## Summary

Fixes conversation-level ST variable macros failing when unknown macros like `{{// comment}}`, `{{trim}}`, or `{{newline}}` appear before `setvar`/`getvar`/`addvar`.

**Root cause**
1. `evaluateMacroBody` returned `"{{$body}}"` for unknown macros; `replaceRange` left text unchanged, so the next scan hit the **same** macro again and burned `while (guard < MAX_MACRO_DEPTH)` (20) without ever reaching later macros.
2. `MAX_MACRO_DEPTH = 20` was also used as the **full-text** expansion budget, so large presets (50–200+ macros) stopped after 20 expansions even without unknown macros.

**Fix** (`ConversationVariables.kt` only)
- ST comment `{{//...}}` → delete (`""`)
- `{{newline}}` → `"\n"`; `{{trim}}` → `""` (MVP: remove macro so it does not block later ones)
- If replacement equals `"{{$body}}"`, advance `searchFrom` past that macro instead of re-scanning forever
- Split nested recursion depth (`MAX_MACRO_DEPTH = 20`) from full-text budget (`MAX_MACRO_EXPANSIONS = 2000`)
- Preserve getvar / setvar / addvar / getglobalvar behavior and count/length caps

## Test plan

- [x] Added unit tests in `VariableMacroTransformerTest`:
  - Prefix `{{// comment}}` then setvar/getvar → `value=bar`, comment gone
  - Multiline ST comment + following macros
  - 100 sequential setvars all applied
  - `{{trim}}` does not block getvar; `{{newline}}` → newline
  - Unknown `{{char}}` left intact without blocking later macros
  - Existing setvar/getvar/addvar/nested/getglobalvar/caps tests retained
- [ ] Unit tests **not run** in this environment (no local JDK/Gradle runner). Please run:
  ```
  ./gradlew :app:testDebugUnitTest --tests me.rerere.rikkahub.data.ai.transformers.VariableMacroTransformerTest
  ```

Fixes #226
Closes #226