### PR TITLE
fix: OFF omits reasoning_effort instead of sending invalid "none"

### DIFF
--- a/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
+++ b/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
@@ -48,7 +48,7 @@ enum class ReasoningDialect {
     @SerialName("auto")
     Auto,
 
-    /** `none|low|medium|high|xhigh` (OpenAI extended / OpenRouter-style). */
+    /** `low|medium|high|xhigh` (OpenAI extended / OpenRouter-style). */
     @SerialName("openai_extended")
     OpenAIExtended,
 
@@ -94,6 +94,8 @@ fun resolveDialect(
  *
  * @return wire token, or `null` when the field should be omitted ([ReasoningLevel.AUTO],
  *   or [ReasoningDialect.OnOffOnly] which only toggles enable/disable in the host branch).
+ *   OFF maps to null (field omitted); OpenAI-compat reasoning_effort vocabularies
+ *   (OpenAI: low|medium|high, DeepSeek: low|high|max) do not accept "none" (#228).
  */
 fun mapReasoningEffort(
     dialect: ReasoningDialect,
@@ -109,10 +111,10 @@ fun mapReasoningEffort(
 
     return when (effective) {
         ReasoningDialect.Auto,
-        ReasoningDialect.OpenAIExtended -> level.effort
+        ReasoningDialect.OpenAIExtended -> if (level == ReasoningLevel.OFF) null else level.effort
 
         ReasoningDialect.OpenAIClassic -> when (level) {
-            ReasoningLevel.OFF -> "none"
+            ReasoningLevel.OFF -> null
             ReasoningLevel.LOW -> "low"
             ReasoningLevel.MEDIUM -> "medium"
             ReasoningLevel.HIGH,
@@ -121,7 +123,7 @@ fun mapReasoningEffort(
         }
 
         ReasoningDialect.DeepSeekMax -> when (level) {
-            ReasoningLevel.OFF -> "none"
+            ReasoningLevel.OFF -> null
             ReasoningLevel.LOW -> "low"
             ReasoningLevel.MEDIUM -> "medium"
             ReasoningLevel.HIGH -> "high"

--- a/ai/src/test/java/me/rerere/ai/core/ReasoningDialectTest.kt
+++ b/ai/src/test/java/me/rerere/ai/core/ReasoningDialectTest.kt
@@ -71,10 +71,7 @@ class ReasoningDialectTest {
             "high",
             mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.HIGH),
         )
-        assertEquals(
-            "none",
-            mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.OFF),
-        )
+        assertNull(mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.OFF))
     }
 
     @Test
@@ -94,19 +91,10 @@ class ReasoningDialectTest {
     }
 
     @Test
-    fun `OFF maps to none never low`() {
-        assertEquals(
-            "none",
-            mapReasoningEffort(ReasoningDialect.OpenAIExtended, ReasoningLevel.OFF),
-        )
-        assertEquals(
-            "none",
-            mapReasoningEffort(ReasoningDialect.OpenAIClassic, ReasoningLevel.OFF),
-        )
-        assertEquals(
-            "none",
-            mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.OFF),
-        )
+    fun `OFF omits effort token`() {
+        assertNull(mapReasoningEffort(ReasoningDialect.OpenAIExtended, ReasoningLevel.OFF))
+        assertNull(mapReasoningEffort(ReasoningDialect.OpenAIClassic, ReasoningLevel.OFF))
+        assertNull(mapReasoningEffort(ReasoningDialect.DeepSeekMax, ReasoningLevel.OFF))
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIReasoningDialectTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIReasoningDialectTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
  * Chat Completions reasoning effort dialect mapping (#207):
  * - official DeepSeek XHIGH → max
  * - mid-station proxy + per-model DeepSeekMax
- * - default OpenAI-compat OFF→none / xhigh passthrough (#214)
+ * - default OpenAI-compat OFF omits reasoning_effort / xhigh passthrough (#214)
  * - unknown hosts keep passthrough for deepseek model ids (#214)
  * - nvidia deepseek-v4 regression
  */
@@ -133,23 +133,25 @@ class ChatCompletionsAPIReasoningDialectTest {
     }
 
     @Test
-    fun `proxy host Auto OFF maps to none not low`() {
+    fun `proxy host Auto OFF omits reasoning_effort`() {
         val body = buildRequest(
             baseUrl = "https://mid.station.example/v1",
             modelId = "deepseek-reasoner",
             reasoningLevel = ReasoningLevel.OFF,
         )
-        assertEquals("none", body["reasoning_effort"]?.jsonPrimitive?.content)
+        assertNull(body["reasoning_effort"])
+        assertFalse(body.containsKey("reasoning_effort"))
     }
 
     @Test
-    fun `default openai-compat OFF maps to none not low`() {
+    fun `default openai-compat OFF omits reasoning_effort`() {
         val body = buildRequest(
             baseUrl = "https://api.openai.com/v1",
             modelId = "o3-mini",
             reasoningLevel = ReasoningLevel.OFF,
         )
-        assertEquals("none", body["reasoning_effort"]?.jsonPrimitive?.content)
+        assertNull(body["reasoning_effort"])
+        assertFalse(body.containsKey("reasoning_effort"))
     }
 
     @Test


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #228

## 变更说明 | Changes

- 问题：OFF 档在通用 OpenAI-compat 分支发送 `reasoning_effort="none"`。OpenAI（含 vLLM 兼容）只接受 `low|medium|high`，DeepSeek 只接受 `low|high|max`，`"none"` 为非法字面值 → HTTP 400。由 #214（PR #221）引入。
- 修复：`mapReasoningEffort` 对 OFF 在 OpenAIExtended / OpenAIClassic / DeepSeekMax 方言统一返回 `null`，从而省略 `reasoning_effort` 字段；OpenRouter 宿主分支与 NVIDIA deepseek-v4 粗粒度表保留既有行为。
- 测试：两处单测 OFF 断言改为省略字段（`assertNull` / `assertFalse(containsKey)`），测试名同步更新。

## 验收条件 | Acceptance criteria

- [ ] OFF 档请求体不再包含 `reasoning_effort` 字段（不再发送非法值 `"none"`）
- [ ] OpenRouter 宿主分支与 NVIDIA deepseek-v4 粗粒度表行为保持不变

## UI 截图 / 录屏 | UI evidence

N/A（无 UI 变更）

## 测试 | Testing

- 命令 / 检查：
  - `grep -rn "\"none\"" ai/src/main --include=*.kt`：核对残留 "none" 映射
  - `grep -n "mapReasoningEffort\|effort" ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt`：确认 OFF 经 mapReasoningEffort 后自动省略
  - 修改并提交两个测试文件（`ReasoningDialectTest.kt`、`ChatCompletionsAPIReasoningDialectTest.kt`）
- 结果：残留 "none" 仅存在于保留范围（OpenRouter 分支、NVIDIA deepseek-v4 粗粒度表、KDoc 注释、`ReasoningLevel` 枚举数据字段 `OFF(0,"none")`——该字段无任何发射路径，`mapReasoningEffort` 与 openrouter 分支均已先行拦截 OFF）。
- 未跑项：本地无 Java/Gradle，编译与单测未执行。

## 数据兼容 | Data compatibility

N/A（无数据库迁移、配置或 API 兼容性影响；修复后请求体省略 `reasoning_effort` 字段）

## 风险与回滚 | Risks and rollback

- 风险：低。改动仅影响 OFF 档 `reasoning_effort` 字段输出（省略而非 `"none"`），更符合 OpenAI-compat 规范。
- 回滚：revert 本 PR 即可恢复旧行为。

## 已知限制 | Known limitations

N/A

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果（编译与单测未执行：本地无 Java/Gradle）
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
