### PR TITLE
feat(#230): use_skill 加载技能时返回技能目录文件清单

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/SkillsTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/SkillsTools.kt
@@ -1,5 +1,6 @@
 package me.rerere.rikkahub.data.ai.tools
 
+import java.io.File
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -80,7 +81,13 @@ fun createSkillTools(
                     require(target.exists()) { "File '$path' not found in skill '$name'" }
                     target.readText()
                 }
-                listOf(UIMessagePart.Text(content))
+                val fileTree = skill.skillDir.walkTopDown()
+                    .filter { it.isFile }
+                    .map { it.relativeTo(skill.skillDir).path.replace(File.separatorChar, '/') }
+                    .sorted()
+                    .joinToString("\n") { "  - $it" }
+                val contentWithTree = content + "\n\n<skill_files>\n$fileTree\n</skill_files>"
+                listOf(UIMessagePart.Text(contentWithTree))
             }
         )
     )

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/tools/SkillsToolsTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/tools/SkillsToolsTest.kt
@@ -12,7 +12,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.data.files.SkillMetadata
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeNoException
 import org.junit.Rule
@@ -38,8 +37,10 @@ class SkillsToolsTest {
                 tool.execute(json("name" to "demo", "path" to "notes.md")).single() as UIMessagePart.Text
                 ).text
 
-            assertEquals("body", body)
-            assertEquals("subfile", subfile)
+            assertTrue(body.startsWith("body"))
+            assertTrue(body.contains("<skill_files>"))
+            assertTrue(subfile.startsWith("subfile"))
+            assertTrue(subfile.contains("<skill_files>"))
         } finally {
             skillDir.parentFile?.deleteRecursively()
         }
@@ -80,7 +81,8 @@ class SkillsToolsTest {
                 tool.execute(json("name" to "demo", "path" to "guide.md")).single() as UIMessagePart.Text
                 ).text
 
-            assertEquals("shared", subfile)
+            assertTrue(subfile.startsWith("shared"))
+            assertTrue(subfile.contains("guide.md"))
         } finally {
             skillDir.parentFile?.deleteRecursively()
             sharedRoot.deleteRecursively()
@@ -139,7 +141,72 @@ class SkillsToolsTest {
             }
         )
 
-        assertEquals("Skill instructions", (result.single() as UIMessagePart.Text).text)
+        val text = (result.single() as UIMessagePart.Text).text
+        assertTrue(text.startsWith("Skill instructions"))
+        assertTrue(text.contains("<skill_files>"))
+    }
+
+    @Test
+    fun useSkill_fileTreeListsSubfilesInReferences() = runBlocking {
+        val skillDir = createSkillDir("demo")
+        try {
+            val refDir = File(skillDir, "references").apply { mkdirs() }
+            File(refDir, "foo.md").writeText("foo")
+            File(refDir, "bar.md").writeText("bar")
+            val tool = createSkillTools(
+                enabledSkills = setOf("demo"),
+                allSkills = listOf(metadata("demo", skillDir)),
+            ).single()
+
+            val body = (tool.execute(json("name" to "demo")).single() as UIMessagePart.Text).text
+
+            assertTrue(body.contains("<skill_files>"))
+            assertTrue(body.contains("references/foo.md"))
+            assertTrue(body.contains("references/bar.md"))
+            assertTrue(body.contains("SKILL.md"))
+        } finally {
+            skillDir.parentFile?.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun useSkill_fileTreeAppendedWhenReadingSubfile() = runBlocking {
+        val skillDir = createSkillDir("demo")
+        try {
+            val refDir = File(skillDir, "references").apply { mkdirs() }
+            File(refDir, "foo.md").writeText("foo")
+            val tool = createSkillTools(
+                enabledSkills = setOf("demo"),
+                allSkills = listOf(metadata("demo", skillDir)),
+            ).single()
+
+            val text = (tool.execute(json("name" to "demo", "path" to "references/foo.md")).single() as UIMessagePart.Text).text
+
+            assertTrue(text.startsWith("foo"))
+            assertTrue(text.contains("<skill_files>"))
+            assertTrue(text.contains("references/foo.md"))
+        } finally {
+            skillDir.parentFile?.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun useSkill_fileTreeOnlySkillMdWhenNoSubfiles() = runBlocking {
+        val skillDir = createSkillDir("demo")
+        try {
+            val tool = createSkillTools(
+                enabledSkills = setOf("demo"),
+                allSkills = listOf(metadata("demo", skillDir)),
+            ).single()
+
+            val body = (tool.execute(json("name" to "demo")).single() as UIMessagePart.Text).text
+
+            assertTrue(body.contains("<skill_files>"))
+            assertTrue(body.contains("SKILL.md"))
+            assertTrue(body.lineSequence().none { it.trim().startsWith("- ") && !it.contains("SKILL.md") })
+        } finally {
+            skillDir.parentFile?.deleteRecursively()
+        }
     }
 
     private fun createSkillDir(name: String): File {


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #230

## 变更说明 | Changes

**背景**：`use_skill` 工具的 `path` 参数要求"Only use paths extracted from Markdown links in the SKILL.md content"，AI 加载技能时完全不知道技能目录里有什么文件（`references/`、`scripts/` 等），只能靠 SKILL.md 作者手动写全引用。本 PR 对齐 Anthropic Agent Skills 的渐进式披露（Progressive Disclosure）设计：**加载技能时自动附带技能目录文件树清单**，让 AI 一加载就能"看到"目录下有哪些文件，再按需读取。

**实现**：`createSkillTools` 的 `execute` 中，读取完内容（SKILL.md 正文或子文件）后，用 `skill.skillDir.walkTopDown()` 过滤文件、转正斜杠相对路径、排序，拼装为 `<skill_files>` 区块追加到返回内容：

```kotlin
val fileTree = skill.skillDir.walkTopDown()
    .filter { it.isFile }
    .map { it.relativeTo(skill.skillDir).path.replace(File.separatorChar, '/') }
    .sorted()
    .joinToString("\n") { "  - $it" }
val contentWithTree = content + "\n\n<skill_files>\n$fileTree\n</skill_files>"
```

**主要改动**：
- `SkillsTools.kt`：`execute` 返回内容追加文件树（约 7 行）
- `SkillsToolsTest.kt`：3 处既有断言改为 `startsWith` + `<skill_files>` 包含检查；新增 3 个测试（references 子文件出现在树中 / 读子文件时也追加文件树 / 无子文件时树仅含 SKILL.md）

## 验收条件 | Acceptance criteria

- [x] AC1: 调用 `use_skill(name="demo")` 时返回 SKILL.md 正文 + `<skill_files>` 文件树，包含 `references/` 下所有文件（`useSkill_fileTreeListsSubfilesInReferences`）
- [x] AC2: 调用 `use_skill(name, path="references/foo.md")` 时返回 foo.md 内容 + 文件树（`useSkill_fileTreeAppendedWhenReadingSubfile`）
- [x] AC3: 无子文件时文件树仅含 SKILL.md，不报错（`useSkill_fileTreeOnlySkillMdWhenNoSubfiles`）
- [x] AC4: 符号链接文件在 `allowedSymlinkRoots` 内时出现在文件树（`walkTopDown` 不跟随符号链接目录但列出链接文件本身，越权路径天然不在 skillDir 下）；`useSkill_readsApprovedSymlinkSubfile` 已更新
- [x] AC5: 既有测试更新（错误分支 `useSkill_rejectsTraversalPath` 断言不变）

## UI 截图 / 录屏 | UI evidence

N/A（纯逻辑功能，无 UI 变更）

## 测试 | Testing

- 命令 / 检查：`git diff 283f07091..HEAD` 人工核验主代码与测试 diff；`git status --short` 确认工作树干净、仅含两个目标文件
- 结果：**本地无 Java/Gradle 环境，未执行构建与测试**（仓库已知限制，构建与真机验证交用户 PC 或 GitHub CI）。测试代码逻辑经人工审阅：断言与改动行为一致，`assertEquals` 已无引用故移除 import，无编译级问题

## 数据兼容 | Data compatibility

N/A（无数据库、配置、API 变更；`use_skill` 返回内容追加文件树，不改变 path 参数语义与错误分支）

## 风险与回滚 | Risks and rollback

- 风险：返回内容体积增加（文件树 token 开销）。技能目录通常很小，可接受；若出现超大目录，可后续按 Issue 内备选方案限制条目数
- 回滚：直接 revert 本 PR 两个 commit 即可，无数据迁移

## 已知限制 | Known limitations

本地沙箱无 Java/Gradle，自动化测试未在本环境执行；需用户 PC 或 GitHub CI 跑 `SkillsToolsTest`。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A（无文档/本地化变更）
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」