### PR TITLE
fix(#244): ModeInjectionEditSheet 改用 Expanded 初始状态消除 show() 竞态

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
@@ -70,7 +70,6 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -867,12 +866,8 @@ internal fun ModeInjectionEditSheet(
     onConfirm: () -> Unit,
     onEdit: (PromptInjection.ModeInjection) -> Unit
 ) {
-    val sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden, enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded))
+    val sheetState = rememberBottomSheetState(initialValue = SheetValue.Expanded, enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded))
     val scope = rememberCoroutineScope()
-
-    LaunchedEffect(sheetState) {
-        sheetState.show()
-    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #244

## 变更说明 | Changes

- 问题：`ModeInjectionEditSheet`（PromptPage.kt:864-876）使用 `rememberBottomSheetState(initialValue = SheetValue.Hidden, ...)` + `LaunchedEffect(sheetState) { sheetState.show() }` 的打开方式——即历史 ui-9 反模式（SheetHiddenThenImmediateShow，曾导致 JsonTree 长按弹 Sheet 闪退）。该 sheet 是活代码，经 ExtensionSelector:322（聊天页扩展面板）与 AssistantExtensionsPage:361 两个入口可达。
- 修复：参照同文件 PresetEditSheet（:448-451）合规写法——
  - `initialValue = SheetValue.Hidden` → `initialValue = SheetValue.Expanded`
  - 删除 `LaunchedEffect(sheetState) { sheetState.show() }` 代码块（消除初始化时序竞态）
  - `enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)` 已合规，保持不变
  - `val scope = rememberCoroutineScope()` 保留（dragHandle 的 `sheetState.hide()` + `onDismiss()` 仍在使用）
  - 顺带删除因此不再使用的 `import androidx.compose.runtime.LaunchedEffect`（全文件零残留）
- 未改动：`onDismissRequest` / `sheetGesturesEnabled = false` / `dragHandle` 逻辑、三个调用方（PromptPage :604、ExtensionSelector:322、AssistantExtensionsPage:361）签名与调用。

## 验收条件 | Acceptance criteria

- [ ] `ModeInjectionEditSheet` 以 Expanded 初始状态组合，不再出现「先 Hidden 再强制 show()」的时序依赖
- [ ] 聊天页扩展面板与助手扩展页的模式注入编辑（新建/编辑）行为正常

## UI 截图 / 录屏 | UI evidence

N/A（无 UI 变更；行为修复，需真机/模拟器验证）

## 测试 | Testing

- 命令 / 检查：
  - `grep -n "LaunchedEffect\|sheetState.show\|initialValue = SheetValue.Hidden" PromptPage.kt`：修复后 `LaunchedEffect`/`sheetState.show` 零命中，仅剩 `SheetValue.Hidden` 出现在 enabledValues 与 PresetEditSheet/Card 等既有合规位置
  - `git diff` 逐行核对：改动仅限该 sheet 的 state 初始化与删除 show() 块（1 文件，+1/-6）
  - 括号配平扫描（PromptPage.kt `{}` 409/409、`()` 854/854）通过
  - `grep -rn "ModeInjectionEditSheet" app/src/main`：4 处调用方签名未变，无编译签名影响
- 结果：以上源码级自查全部通过。
- **未跑项：本地无 Java/Gradle，未编译、未真机验证。**

## 数据兼容 | Data compatibility

N/A（无数据库迁移、配置或 API 兼容性影响；纯 UI 初始化时序修复）

## 风险与回滚 | Risks and rollback

- 风险：低。改动与仓库既有 PresetEditSheet 合规写法一致；`enabledValues` 与 `sheetGesturesEnabled=false` 保持原样，行为语义不变。
- 回滚：revert 本 PR 即可恢复旧行为。

## 已知限制 | Known limitations

- 未编译、未真机验证；sheet 打开动画的实际表现需真机冒烟确认。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」