### PR TITLE
fix(#244): use Expanded initial state for ModeInjectionEditSheet

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
@@ -867,12 +867,8 @@ internal fun ModeInjectionEditSheet(
     onConfirm: () -> Unit,
     onEdit: (PromptInjection.ModeInjection) -> Unit
 ) {
-    val sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden, enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded))
+    val sheetState = rememberBottomSheetState(initialValue = SheetValue.Expanded, enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded))
     val scope = rememberCoroutineScope()
-
-    LaunchedEffect(sheetState) {
-        sheetState.show()
-    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #244

## 变更说明 | Changes

修复 #244：`ModeInjectionEditSheet`（`app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt`）此前使用历史 ui-9 反模式（SheetHiddenThenImmediateShow）——`rememberBottomSheetState(initialValue = SheetValue.Hidden)` 组合后经 `LaunchedEffect(sheetState) { sheetState.show() }` 强制 show，存在初始化时序竞态（低概率闪退/闪烁）。

改动（3 行 state 初始化）：

- `rememberBottomSheetState` 初始值由 `SheetValue.Hidden` 改为 `SheetValue.Expanded`，`enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded)` 保持不变；
- 删除紧随其后的 `LaunchedEffect(sheetState) { sheetState.show() }` 块，消除时序依赖；
- 保留 `dragHandle` 的 `sheetState.hide()` + `onDismiss()` 与 `sheetGesturesEnabled = false` 不变。

与同文件合规写法 `PresetEditSheet`（PromptPage.kt:431-434，`initialValue = Expanded`）对齐，遵循项目 sheet 规范（ui-78 Sheet 锚点规范 / ui-9 Sheet 显隐时机规范）。

## 验收条件 | Acceptance criteria

- [ ] 聊天页扩展面板（ExtensionSelector）进入/新建「模式注入」编辑 sheet，打开即全高展开，无闪烁、无竞态
- [ ] 助手扩展页（AssistantExtensionsPage）进入「模式注入」编辑 sheet 同样正常
- [ ] sheet 内拖拽关闭/箭头按钮关闭仍正常（dragHandle 保留 hide()+onDismiss()）

## UI 截图 / 录屏 | UI evidence

N/A（无行为可见变化；仅消除初始化时序竞态）

## 测试 | Testing

- 命令 / 检查：
  - `git diff` 核对改动仅限 `ModeInjectionEditSheet` 的 sheetState 初始化（1 insertion / 5 deletions）
  - `grep` 验证文件内 `sheetState.show()` 已无残留，`rememberBottomSheetState` 初始化仅剩两处（PresetEditSheet + ModeInjectionEditSheet）
- 结果：
  - 未执行：无本地 Gradle/编译环境，未跑编译与静态检查
  - 未执行：无真机/模拟器，未验证运行表现（建议合并后按验收条件人工验证）

## 数据兼容 | Data compatibility

N/A（纯 UI 状态初始化改动，无数据面影响）

## 风险与回滚 | Risks and rollback

- 风险：极低。`initialValue = Expanded` 为项目既有合规模式（PresetEditSheet 同款），`enabledValues` 未变，Hidden 仍为合法状态，关闭行为不受影响
- 回滚：revert 本提交即可恢复原状

## 已知限制 | Known limitations

文件内 `LaunchedEffect` import（PromptPage.kt:73）在本次删除唯一调用点后成为未使用 import。仓库无 lint 门禁（pr-apk.yml 仅手动构建），不影响编译；按任务指示保留，如需清理可后续单独处理。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」