### PR TITLE
fix(#246): buffer preset name/description edits and commit on focus loss

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PresetDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PresetDetailPage.kt
@@ -41,13 +41,16 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
@@ -216,6 +219,34 @@ private fun PresetDetailContent(
         }
     }
 
+    // #246: 名称/描述文本字段局部缓冲——输入过程只更新本地 state，失焦/退栈时提交，
+    // 避免每击键一次 DataStore 写导致快速返回时最后几次击键随 viewModelScope 取消而丢失。
+    var nameText by remember(preset.name) { mutableStateOf(preset.name) }
+    var descriptionText by remember(preset.description) { mutableStateOf(preset.description) }
+    val latestNameText by rememberUpdatedState(nameText)
+    val latestDescriptionText by rememberUpdatedState(descriptionText)
+
+    fun commitName() {
+        if (latestNameText != preset.name) {
+            onMutatePreset { it.copy(name = latestNameText) }
+        }
+    }
+
+    fun commitDescription() {
+        if (latestDescriptionText != preset.description) {
+            onMutatePreset { it.copy(description = latestDescriptionText) }
+        }
+    }
+
+    // 退栈/销毁前 flush 未提交的文本缓冲（composition dispose 先于 ViewModel onCleared，
+    // 给最后一次写留出窗口）。与 AssistantMemoryTableDocumentEditorPage 的 DisposableEffect 模式一致。
+    DisposableEffect(Unit) {
+        onDispose {
+            commitName()
+            commitDescription()
+        }
+    }
+
     LazyColumn(
         modifier = modifier.padding(16.dp),
         state = lazyListState,
@@ -224,19 +255,31 @@ private fun PresetDetailContent(
     ) {
         item(key = "name") {
             OutlinedTextField(
-                value = preset.name,
-                onValueChange = { name -> onMutatePreset { it.copy(name = name) } },
+                value = nameText,
+                onValueChange = { nameText = it },
                 label = { Text(stringResource(R.string.prompt_page_name)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onFocusChanged { focusState ->
+                        if (!focusState.isFocused) {
+                            commitName()
+                        }
+                    },
                 singleLine = true,
             )
         }
         item(key = "description") {
             OutlinedTextField(
-                value = preset.description,
-                onValueChange = { description -> onMutatePreset { it.copy(description = description) } },
+                value = descriptionText,
+                onValueChange = { descriptionText = it },
                 label = { Text(stringResource(R.string.prompt_page_description)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onFocusChanged { focusState ->
+                        if (!focusState.isFocused) {
+                            commitDescription()
+                        }
+                    },
                 minLines = 2,
             )
         }


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #246

## 变更说明 | Changes

修复预设详情页名称/描述文本字段**逐键落盘、快速返回丢最后一次编辑**的问题（仅改 `PresetDetailPage.kt` 单文件）。

**问题根因**：名称/描述 `OutlinedTextField` 的 `onValueChange` 每击键调用 `onMutatePreset → vm.updatePreset → DataStore 写`（viewModelScope 协程）。快速返回时协程随 NavBackStackEntry 的 ViewModel 销毁被取消，最后一次/几次击键静默丢失。

**修复方案**（在 `PresetDetailContent` 内，参照同文件 `DraftContextSection` 的局部缓冲心智 + `AssistantMemoryTableDocumentEditorPage` 的 `DisposableEffect` 模式）：

- 名称/描述引入局部缓冲 state：`nameText` / `descriptionText`（`remember(preset.name)` / `remember(preset.description)` 初始化），`onValueChange` 只更新本地 state，**不再逐键写 DataStore**
- `onFocusChanged` 失焦时提交：`commitName()` / `commitDescription()`（值有变化才调用 `onMutatePreset`，无变化不写）
- `DisposableEffect(Unit).onDispose` 退栈/销毁前 flush 未提交内容（composition dispose 先于 ViewModel `onCleared` 执行，给最后一次写留出窗口）
- `rememberUpdatedState` 保证 onDispose 闭包捕获最新缓冲值

**DataStore 层**：核查确认 `PreferencesStore.updatePreset` 已是 `dataStore.edit` 原子部分写（`writePresetUpdate`，非读快照全量覆盖），故未动。

## 验收条件 | Acceptance criteria

- [x] 名称/描述 `onValueChange` 不再调用 `onMutatePreset`（grep 确认仅 `commitName`/`commitDescription` 提交点及非文本字段操作调用）
- [x] 失焦提交 + 退栈 flush 均已实现，`DisposableEffect` 模式与仓库既有写法一致
- [x] 只改 `PresetDetailPage.kt` 单文件，`DraftContextSection` 未动
- [x] 新增 import（`DisposableEffect`/`rememberUpdatedState`/`onFocusChanged`）无重复、均有使用，按仓库字母序插入

## UI 截图 / 录屏 | UI evidence

N/A（无 UI 变更；失焦前 ListItem 预览等依赖 preset 字段的 UI 显示旧值属预期，与 `DraftContextSection` 行为一致）

## 测试 | Testing

无本地编译环境，未运行编译/构建；通过以下静态核对：

- 命令 / 检查：`grep -n "onValueChange"` 名称/描述输入框 → 仅 `nameText = it` / `descriptionText = it`，不再直接调 `onMutatePreset`
- 命令 / 检查：`grep -n "onMutatePreset"` → 文本字段提交点仅 `commitName`/`commitDescription`（:231/:237）
- 命令 / 检查：大括号配对平衡校验 → 0（OK）
- 命令 / 检查：import 重复校验 → 无重复；新增 import 均有使用（各 3 处）
- 结果：全部通过

## 数据兼容 | Data compatibility

N/A（无数据格式/存储变更；`updatePreset` 原子部分写保持原样，仅文本提交时机从逐键改为失焦/退栈）

## 风险与回滚 | Risks and rollback

- 风险：低。改动局限在名称/描述两个输入框的提交时机；失焦/退栈提交覆盖用户主路径
- 残余风险（如实说明）：`onDispose` flush 启动的 viewModelScope 写协程，在 ViewModelStore 极快被清理的极端竞态下仍可能被取消（Compose 的 onDispose 时序上先于 `onCleared`，但无法保证 `dataStore.edit` 在清理前完成）。失焦提交已覆盖绝大部分场景；若需彻底消除可后续将最后一次写改为非 viewModelScope 提交作用域（超出本 PR 最小范围，未做）
- 回滚：`git revert` 即可

## 已知限制 | Known limitations

- 未运行编译（无本地 Gradle 环境）；已通过引用/边界/括号静态核对
- 失焦前依赖 `preset.name`/`preset.description` 的 UI（如 TopAppBar 标题、条目引用标题）显示旧值为预期行为

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」