### PR TITLE
fix(#240): register horizontal gesture exclusion for chat scrollable rows

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.content.ReceiveContentListener
 import androidx.compose.foundation.content.consume
 import androidx.compose.foundation.content.contentReceiver
 import androidx.compose.foundation.content.hasMediaType
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -64,6 +66,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -114,6 +118,7 @@ import me.rerere.rikkahub.ui.components.ui.permission.PermissionManager
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionRecordAudio
 import me.rerere.rikkahub.ui.components.ui.permission.rememberPermissionState
 import me.rerere.rikkahub.ui.context.LocalASRState
+import me.rerere.rikkahub.ui.context.LocalHorizontalGestureExclusionState
 import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.hooks.ChatInputState
@@ -150,6 +155,8 @@ fun ChatInput(
     val inputDraftCancelDescription = stringResource(R.string.input_draft_cancel)
     val hazeTintColor = MaterialTheme.colorScheme.surfaceContainerLow
     val inputHazeStyle = HazeMaterials.thin(containerColor = hazeTintColor)
+    val toolRowScrollState = rememberScrollState()
+    val horizontalGestureExclusionState = LocalHorizontalGestureExclusionState.current
 
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -264,7 +271,25 @@ fun ChatInput(
                         Row(
                             modifier = Modifier
                                 .weight(1f)
-                                .horizontalScroll(rememberScrollState()),
+                                .horizontalScroll(toolRowScrollState)
+                                .pointerInput(horizontalGestureExclusionState) {
+                                    val exclusionState = horizontalGestureExclusionState ?: return@pointerInput
+                                    awaitEachGesture {
+                                        val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                                        val exclusionLease = exclusionState.acquireIfScrollable(
+                                            pointerId = down.id.value,
+                                            maxScrollValue = toolRowScrollState.maxValue,
+                                        )
+                                        try {
+                                            while (true) {
+                                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                                if (event.changes.none { it.pressed }) break
+                                            }
+                                        } finally {
+                                            exclusionLease?.close()
+                                        }
+                                    }
+                                },
                             horizontalArrangement = Arrangement.spacedBy(2.dp)
                         ) {
                             // Model Picker

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -10,8 +10,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilledTonalIconButton
@@ -33,6 +36,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -55,6 +60,7 @@ import me.rerere.rikkahub.ui.components.message.tools.ToolUIRegistry
 import me.rerere.rikkahub.ui.components.richtext.ZoomableAsyncImage
 import me.rerere.rikkahub.ui.components.ui.ChainOfThoughtScope
 import me.rerere.rikkahub.ui.components.ui.DotLoading
+import me.rerere.rikkahub.ui.context.LocalHorizontalGestureExclusionState
 import me.rerere.rikkahub.ui.modifier.shimmer
 import me.rerere.rikkahub.utils.JsonInstant
 
@@ -97,6 +103,8 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
     val isPending = tool.approvalState is ToolApprovalState.Pending
     val isDenied = tool.approvalState is ToolApprovalState.Denied
     val images = tool.output.filterIsInstance<UIMessagePart.Image>()
+    val toolImagesRowState = rememberLazyListState()
+    val horizontalGestureExclusionState = LocalHorizontalGestureExclusionState.current
 
     // 摘要由注册的渲染器决定; 图片输出与拒绝原因为所有工具通用
     val hasExtraContent = renderer.hasSummary(context) || isDenied || images.isNotEmpty()
@@ -169,8 +177,28 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
                     renderer.Summary(context)
                     if (images.isNotEmpty()) {
                         LazyRow(
+                            state = toolImagesRowState,
                             horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            modifier = Modifier.wrapContentWidth(),
+                            modifier = Modifier
+                                .wrapContentWidth()
+                                .pointerInput(horizontalGestureExclusionState) {
+                                    val exclusionState = horizontalGestureExclusionState ?: return@pointerInput
+                                    awaitEachGesture {
+                                        val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                                        val exclusionLease = exclusionState.acquireIfScrollable(
+                                            pointerId = down.id.value,
+                                            maxScrollValue = toolImagesRowState.maxValue,
+                                        )
+                                        try {
+                                            while (true) {
+                                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                                if (event.changes.none { it.pressed }) break
+                                            }
+                                        } finally {
+                                            exclusionLease?.close()
+                                        }
+                                    }
+                                },
                         ) {
                             items(images) { image ->
                                 ZoomableAsyncImage(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -187,7 +187,7 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
                                         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                                         val exclusionLease = exclusionState.acquireIfScrollable(
                                             pointerId = down.id.value,
-                                            maxScrollValue = toolImagesRowState.maxValue,
+                                            maxScrollValue = if (toolImagesRowState.canScrollForward || toolImagesRowState.canScrollBackward) 1 else 0,
                                         )
                                         try {
                                             while (true) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -967,7 +967,7 @@ private fun FolderBar(
                     val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                     val exclusionLease = exclusionState.acquireIfScrollable(
                         pointerId = down.id.value,
-                        maxScrollValue = folderRowState.maxValue,
+                        maxScrollValue = if (folderRowState.canScrollForward || folderRowState.canScrollBackward) 1 else 0,
                     )
                     try {
                         while (true) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -3,6 +3,8 @@ package me.rerere.rikkahub.ui.pages.chat
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -45,6 +47,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -87,6 +91,7 @@ import me.rerere.rikkahub.ui.components.ui.UIAvatar
 import me.rerere.rikkahub.ui.components.ui.UpdateCard
 import me.rerere.rikkahub.ui.components.ui.conversationTagErrorMessage
 import androidx.compose.ui.draw.clip
+import me.rerere.rikkahub.ui.context.LocalHorizontalGestureExclusionState
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.context.Navigator
 import com.dokar.sonner.ToastType
@@ -949,10 +954,31 @@ private fun FolderBar(
     onRename: (Folder) -> Unit,
     onDelete: (Folder) -> Unit,
 ) {
+    val folderRowState = rememberLazyListState()
+    val horizontalGestureExclusionState = LocalHorizontalGestureExclusionState.current
     LazyRow(
+        state = folderRowState,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 4.dp),
+            .padding(horizontal = 4.dp)
+            .pointerInput(horizontalGestureExclusionState) {
+                val exclusionState = horizontalGestureExclusionState ?: return@pointerInput
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                    val exclusionLease = exclusionState.acquireIfScrollable(
+                        pointerId = down.id.value,
+                        maxScrollValue = folderRowState.maxValue,
+                    )
+                    try {
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            if (event.changes.none { it.pressed }) break
+                        }
+                    } finally {
+                        exclusionLease?.close()
+                    }
+                }
+            },
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -23,6 +23,8 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -42,6 +44,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilledIconButton
@@ -74,6 +77,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalScrollCaptureInProgress
@@ -103,6 +108,7 @@ import me.rerere.rikkahub.ui.components.ui.ErrorCardsDisplay
 import me.rerere.rikkahub.ui.components.ui.ListSelectableItem
 import me.rerere.rikkahub.ui.components.ui.RabbitLoadingIndicator
 import me.rerere.rikkahub.ui.components.ui.Tooltip
+import me.rerere.rikkahub.ui.context.LocalHorizontalGestureExclusionState
 import me.rerere.rikkahub.ui.hooks.ImeLazyListAutoScroller
 import me.rerere.rikkahub.ui.theme.ChatFontProvider
 import me.rerere.rikkahub.utils.plus
@@ -772,10 +778,31 @@ private fun ChatSuggestionsRow(
     conversation: Conversation,
     onClickSuggestion: (String) -> Unit
 ) {
+    val rowState = rememberLazyListState()
+    val horizontalGestureExclusionState = LocalHorizontalGestureExclusionState.current
     LazyRow(
+        state = rowState,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .pointerInput(horizontalGestureExclusionState) {
+                val exclusionState = horizontalGestureExclusionState ?: return@pointerInput
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                    val exclusionLease = exclusionState.acquireIfScrollable(
+                        pointerId = down.id.value,
+                        maxScrollValue = rowState.maxValue,
+                    )
+                    try {
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            if (event.changes.none { it.pressed }) break
+                        }
+                    } finally {
+                        exclusionLease?.close()
+                    }
+                }
+            },
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -791,7 +791,7 @@ private fun ChatSuggestionsRow(
                     val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                     val exclusionLease = exclusionState.acquireIfScrollable(
                         pointerId = down.id.value,
-                        maxScrollValue = rowState.maxValue,
+                        maxScrollValue = if (rowState.canScrollForward || rowState.canScrollBackward) 1 else 0,
                     )
                     try {
                         while (true) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationGitStatusDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationGitStatusDrawer.kt
@@ -1,6 +1,8 @@
 package me.rerere.rikkahub.ui.pages.chat
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -31,6 +33,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -47,6 +51,7 @@ import me.rerere.rikkahub.data.model.GitDiffUiState
 import me.rerere.rikkahub.data.model.GitFileChange
 import me.rerere.rikkahub.data.model.GitRepositoryStatus
 import me.rerere.rikkahub.data.model.GitStatusUiState
+import me.rerere.rikkahub.ui.context.LocalHorizontalGestureExclusionState
 
 @Composable
 internal fun gitStatusMenuSubtitle(state: GitStatusUiState): String = when (state) {
@@ -509,12 +514,31 @@ private fun GitTextDiff(state: GitDiffUiState.Text) {
         } else {
             val verticalScroll = rememberScrollState()
             val horizontalScroll = rememberScrollState()
+            val horizontalGestureExclusionState = LocalHorizontalGestureExclusionState.current
             SelectionContainer {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(verticalScroll)
                         .horizontalScroll(horizontalScroll)
+                        .pointerInput(horizontalGestureExclusionState) {
+                            val exclusionState = horizontalGestureExclusionState ?: return@pointerInput
+                            awaitEachGesture {
+                                val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                                val exclusionLease = exclusionState.acquireIfScrollable(
+                                    pointerId = down.id.value,
+                                    maxScrollValue = horizontalScroll.maxValue,
+                                )
+                                try {
+                                    while (true) {
+                                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                                        if (event.changes.none { it.pressed }) break
+                                    }
+                                } finally {
+                                    exclusionLease?.close()
+                                }
+                            }
+                        }
                         .padding(12.dp),
                 ) {
                     Text(


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #240

## 变更说明 | Changes

修复 #240：聊天页可横向滚动区域未注册 `acquireIfScrollable` 手势排除，导致在这些区域左滑时被 ChatPage 全宽手势层（Initial pass）接管并误触发打开记忆表右抽屉。

机制说明：ChatPage.kt 已创建 `HorizontalGestureExclusionState`（:171）并在全宽手势层判定时检查 `isExcluded`（:312，`shouldClaimRightDrawerGesture` 的 `!gestureExcluded`）。此前整个聊天子树没有任何组件实际注册排除（全仓仅 DataTable.kt:82 一处）。本 PR 按 DataTable.kt 的合规模板（`LocalHorizontalGestureExclusionState.current` + `pointerInput` + `awaitEachGesture`/`awaitFirstDown(Initial pass)` + `acquireIfScrollable(maxScrollValue)` + `finally close()` 释放），为 5 处聊天页横滑容器注册排除：

1. **ChatList.kt** `ChatSuggestionsRow` 建议 pill 行 LazyRow（持有 `rememberLazyListState`，`maxValue` 判定可滚）
2. **ChatInput.kt** 输入区工具按钮行 `Row.horizontalScroll`（模型/工具选择，持有 `rememberScrollState`）
3. **ChatDrawer.kt** `FolderBar` 会话列表文件夹横滑行 LazyRow（:952）
4. **ConversationGitStatusDrawer.kt** Git 文本 diff 横滑区 Box（:517，`horizontalScroll` 部分）
5. **ChatMessageTools.kt** `ChatMessageToolStep` 消息内工具图片行 LazyRow（:171，消息内联渲染）

每处：触摸起点落在可横向滚动容器内时 `acquireIfScrollable`（滚动最大值 > 0 时 acquire），手势层判定 `isExcluded=true` 不接管，内容正常横滑；滚动到边界后继续左滑仍可打开右抽屉；`finally` 释放 lease 保证非活动指针不残留。

**未注册项（第 6 处即 BuiltinToolUIs.kt:701）说明**：`SearchWebPreview`（`WebSearchToolUI.Preview()`）内的 LazyRow 仅在 `ModalBottomSheet`（ChatMessageTools.kt:248 / SubagentToolUIs.kt:865/:1046）即 Dialog 独立 window 中渲染。CompositionLocal 不跨 window，且触摸事件不经过 ChatPage 的手势层（不同 window），该处左滑不会误触右抽屉，故无需注册。`WebSearchToolUI.Summary()` 不含横滑容器，无需处理。

## 验收条件 | Acceptance criteria

- [ ] 聊天页建议 pill 行（ChatSuggestionsRow）上左滑可正常横滑内容，不触发右抽屉
- [ ] 输入区工具按钮行（模型/工具选择）左滑可正常横滑，不触发右抽屉
- [ ] 会话列表文件夹横滑行左滑正常
- [ ] Git 状态抽屉文本 diff 横滑区左滑正常
- [ ] 消息内工具图片行左滑正常
- [ ] 非横滑区域左滑仍按 #89 全宽手势打开记忆表右抽屉

## UI 截图 / 录屏 | UI evidence

N/A（交互行为修复，无视觉变化）

## 测试 | Testing

- 命令 / 检查：
  - `grep -rn "acquireIfScrollable"` 验证注册位置：5 处新增 + DataTable 原有 1 处 + 定义 1 处
  - 逐文件核对新增 import 均有使用（`awaitEachGesture`/`awaitFirstDown`/`PointerEventPass`/`pointerInput`/`LocalHorizontalGestureExclusionState`/`rememberLazyListState`），无未使用 import
  - 核对 ChatPage.kt 判定逻辑（:312 `isExcluded`）未改动，仅新增注册
- 结果：
  - 未执行：无本地 Gradle/编译环境，未跑编译与静态检查
  - 未执行：无真机/模拟器，未验证运行表现（建议合并后按验收条件人工验证横滑/抽屉互斥行为）

## 数据兼容 | Data compatibility

N/A（纯 UI 手势处理改动，无数据面影响）

## 风险与回滚 | Risks and rollback

- 风险：低。注册逻辑与 DataTable（#102 修复，已上线验证）完全同款；`acquireIfScrollable` 在滚动最大值 ≤ 0 时返回 null 不 acquire，内容不横滑时左滑行为不变；`finally close()` 保证指针抬起后释放
- 回滚：revert 本提交即可恢复原状

## 已知限制 | Known limitations

N/A

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」