### PR TITLE
fix(#235): enforce 48dp touch targets for small clickable elements

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -183,6 +184,7 @@ private fun AttachmentChip(
             Box(
                 modifier = Modifier
                     .clip(CircleShape)
+                    .minimumInteractiveComponentSize()
                     .size(26.dp)
                     .clickable(onClick = onRemove),
                 contentAlignment = Alignment.Center

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -24,7 +24,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -385,6 +386,7 @@ fun ChatInput(
                                 contentAlignment = Alignment.Center,
                                 modifier = Modifier
                                     .size(30.dp)
+                                    .minimumInteractiveComponentSize()
                                     .testTag("chat_send_button")
                                     .clip(CircleShape)
                                     .combinedClickable(
@@ -446,7 +448,7 @@ private fun ActionIconButton(
     Surface(
         onClick = onClick,
         enabled = enabled,
-        modifier = Modifier.size(30.dp),
+        modifier = Modifier.size(30.dp).minimumInteractiveComponentSize(),
         shape = CircleShape,
         tonalElevation = 0.dp,
         color = Color.Transparent,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -24,7 +24,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -104,6 +105,7 @@ fun ColumnScope.ChatMessageActionButtons(
             contentDescription = stringResource(R.string.copy),
             modifier = Modifier
                 .clip(CircleShape)
+                .minimumInteractiveComponentSize()
                 .clickable { context.copyMessageToClipboard(message) }
                 .padding(8.dp)
                 .size(16.dp),
@@ -115,6 +117,7 @@ fun ColumnScope.ChatMessageActionButtons(
             contentDescription = stringResource(R.string.regenerate),
             modifier = Modifier
                 .clip(CircleShape)
+                .minimumInteractiveComponentSize()
                 .clickable {
                     if (message.role == MessageRole.USER) {
                         showRegenerateConfirm = true
@@ -136,6 +139,7 @@ fun ColumnScope.ChatMessageActionButtons(
                 contentDescription = stringResource(R.string.tts),
                 modifier = Modifier
                     .clip(CircleShape)
+                    .minimumInteractiveComponentSize()
                     .clickable(
                         enabled = isAvailable,
                         interactionSource = remember { MutableInteractionSource() },
@@ -168,6 +172,7 @@ fun ColumnScope.ChatMessageActionButtons(
                     contentDescription = stringResource(R.string.translate),
                     modifier = Modifier
                         .clip(CircleShape)
+                        .minimumInteractiveComponentSize()
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = LocalIndication.current,
@@ -187,6 +192,7 @@ fun ColumnScope.ChatMessageActionButtons(
             contentDescription = stringResource(R.string.more_options),
             modifier = Modifier
                 .clip(CircleShape)
+                .minimumInteractiveComponentSize()
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = LocalIndication.current,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageBranch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageBranch.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -42,6 +43,7 @@ fun ChatMessageBranchSelector(
                 contentDescription = "Prev",
                 modifier = Modifier
                     .clip(CircleShape)
+                    .minimumInteractiveComponentSize()
                     .alpha(if (node.selectIndex == 0) 0.5f else 1f)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
@@ -72,6 +74,7 @@ fun ChatMessageBranchSelector(
                 contentDescription = "Next",
                 modifier = Modifier
                     .clip(CircleShape)
+                    .minimumInteractiveComponentSize()
                     .alpha(if (node.selectIndex == node.messages.lastIndex) 0.5f else 1f)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageBranch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageBranch.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageBranch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageBranch.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -135,7 +135,6 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
                 ) {
                     FilledTonalIconButton(
                         onClick = { showDenyDialog = true },
-                        modifier = Modifier.size(28.dp),
                     ) {
                         Icon(
                             imageVector = HugeIcons.Cancel01,
@@ -145,7 +144,6 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
                     }
                     FilledTonalIconButton(
                         onClick = { onToolApproval(tool.toolCallId, true, "") },
-                        modifier = Modifier.size(28.dp),
                     ) {
                         Icon(
                             imageVector = HugeIcons.Tick01,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/BuiltinToolUIs.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/BuiltinToolUIs.kt
@@ -301,7 +301,6 @@ object TextToSpeechToolUI : ToolUIRenderer {
             )
             FilledTonalIconButton(
                 onClick = { scope.launch { eventBus.emit(AppEvent.Speak(text)) } },
-                modifier = Modifier.size(28.dp),
             ) {
                 Icon(
                     imageVector = HugeIcons.Refresh01,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -66,6 +67,7 @@ fun <T> Select(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(4.dp))
+                    .minimumInteractiveComponentSize()
                     .clickable { expanded = true }
                     .padding(vertical = 8.dp, horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -95,6 +96,7 @@ fun Switch(
     Box(
         modifier = modifier
             .size(width = dimensions.trackWidth, height = dimensions.trackHeight)
+            .minimumInteractiveComponentSize()
             .clip(RoundedCornerShape(50))
             .background(currentTrackColor)
             .clickable(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Switch.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TagList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TagList.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -65,6 +66,7 @@ fun TagsInput(
                     contentDescription = null,
                     modifier = Modifier
                         .size(16.dp)
+                        .minimumInteractiveComponentSize()
                         .clickable {
                             onValueChange(
                                 value.filter { it != tag.id }, tags
@@ -81,6 +83,7 @@ fun TagsInput(
             tonalElevation = 2.dp,
             modifier = Modifier
                 .clip(CircleShape)
+                .minimumInteractiveComponentSize()
                 .clickable { showAddDialog = true }) {
             Icon(
                 imageVector = HugeIcons.Add01,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TagList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TagList.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TagList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TagList.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape

--- a/app/src/main/java/me/rerere/rikkahub/ui/modifier/Clickable.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/modifier/Clickable.kt
@@ -3,6 +3,7 @@ package me.rerere.rikkahub.ui.modifier
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -12,7 +13,7 @@ import androidx.compose.ui.semantics.Role
 fun Modifier.onClick(
     enabled: Boolean = true,
     onClick: () -> Unit
-): Modifier = this.then(Modifier.clickable(
+): Modifier = this.then(Modifier.minimumInteractiveComponentSize()).then(Modifier.clickable(
     onClick = onClick,
     interactionSource = remember { MutableInteractionSource() },
     indication = LocalIndication.current,

--- a/app/src/main/java/me/rerere/rikkahub/ui/modifier/Clickable.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/modifier/Clickable.kt
@@ -3,7 +3,7 @@ package me.rerere.rikkahub.ui.modifier
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/me/rerere/rikkahub/ui/modifier/Clickable.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/modifier/Clickable.kt
@@ -3,7 +3,7 @@ package me.rerere.rikkahub.ui.modifier
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -766,6 +767,7 @@ private fun TagFilterControl(
                     contentDescription = stringResource(R.string.conversation_tag_filter_clear),
                     modifier = Modifier
                         .clip(CircleShape)
+                        .minimumInteractiveComponentSize()
                         .clickable(onClick = onClear)
                         .padding(6.dp)
                         .size(16.dp),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.minimumInteractiveComponentSize
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.minimumInteractiveComponentSize
+import androidx.compose.foundation.minimumInteractiveComponentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
@@ -1597,7 +1597,6 @@ private fun RegexInjectionEditFullscreen(
                                     onClick = {
                                         onEdit(entry.copy(keywords = entry.keywords - keyword))
                                     },
-                                    modifier = Modifier.size(16.dp)
                                 ) {
                                     Icon(HugeIcons.Cancel01, null, modifier = Modifier.size(12.dp))
                                 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/skills/SkillDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/skills/SkillDetailPage.kt
@@ -408,7 +408,7 @@ private fun FileItem(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            IconButton(onClick = onEdit, modifier = Modifier.size(36.dp)) {
+            IconButton(onClick = onEdit) {
                 Icon(
                     imageVector = Lucide.FilePen,
                     contentDescription = stringResource(R.string.edit),
@@ -416,7 +416,7 @@ private fun FileItem(
                 )
             }
             if (skillFile.relativePath != "SKILL.md") {
-                IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+                IconButton(onClick = onDelete) {
                     Icon(
                         imageVector = Lucide.Trash2,
                         contentDescription = stringResource(R.string.delete),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/imggen/ImgGenPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/imggen/ImgGenPage.kt
@@ -713,14 +713,14 @@ private fun ActiveGenerationJobSection(
                     )
                 }
                 if (job.isRunning) {
-                    IconButton(onClick = onCancel, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = onCancel) {
                         Icon(HugeIcons.Cancel01, contentDescription = null, modifier = Modifier.size(18.dp))
                     }
                 } else {
-                    IconButton(onClick = onRegenerateJob, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = onRegenerateJob) {
                         Icon(HugeIcons.Refresh01, contentDescription = null, modifier = Modifier.size(18.dp))
                     }
-                    IconButton(onClick = onDismiss, modifier = Modifier.size(32.dp)) {
+                    IconButton(onClick = onDismiss) {
                         Icon(HugeIcons.Delete01, contentDescription = null, modifier = Modifier.size(18.dp))
                     }
                 }
@@ -1690,7 +1690,7 @@ private fun CollapsibleSectionHeader(
         }
         if (onRename != null || onDelete != null) {
             Box {
-                IconButton(onClick = { showMenu = true }, modifier = Modifier.size(32.dp)) {
+                IconButton(onClick = { showMenu = true }) {
                     Icon(HugeIcons.MoreVertical, contentDescription = null, modifier = Modifier.size(18.dp))
                 }
                 DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
@@ -276,7 +276,7 @@ private fun ModelSettingItem(
                             overflow = TextOverflow.Ellipsis,
                         )
                         if (onClear != null && state.currentModel != null) {
-                            IconButton(onClick = onClear, modifier = Modifier.size(20.dp)) {
+                            IconButton(onClick = onClear) {
                                 Icon(HugeIcons.Cancel01, contentDescription = null, modifier = Modifier.size(14.dp))
                             }
                         } else {


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #235

## 变更说明 | Changes

全仓自定义 clickable 触摸目标不足 48dp（部分仅 16dp 热区）。material3 1.5.0-alpha25 的 `minimumInteractiveComponentSize()` 可用（全仓此前 0 处使用）。按改动分组修复：

### A. 裸 clickable 小图标（在 `.clip()` 后、`.clickable` 前插入 `minimumInteractiveComponentSize()`，视觉不变、热区扩至 48dp）
- `ChatMessageActions.kt`：复制/重新生成/TTS/翻译/更多 5 个 16dp 图标
- `ChatMessageBranch.kt`：分支切换 2 个 16dp 图标
- `ChatDrawer.kt`：TagFilterControl 清空图标（≈28dp）
- `AttachmentChips.kt`：附件删除按钮（26dp）

### B. M3 IconButton/FilledTonalIconButton 显式 size 覆盖（显式 `size(<48dp)` 会覆盖 M3 自带 48dp 兜底 → 去掉 size，恢复兜底）
- `SettingModelPage.kt` 20dp、`SkillDetailPage.kt` 36dp×2、`ImgGenPage.kt` 32dp×4、`ChatMessageTools.kt` 28dp×2、`BuiltinToolUIs.kt` 28dp、`PromptPage.kt` 16dp（InputChip trailing）

### C. 自研组件根加 `minimumInteractiveComponentSize()`（一处改全生效）
- `Select.kt` 下拉按钮（高≈36dp）、`Switch.kt` 自定义 Switch（track 高 20-28dp）、`TagList.kt` InputChip 删除图标 16dp + 添加按钮 ≈28dp

### D. onClick 封装根治
- `ui/modifier/Clickable.kt` 的 `Modifier.onClick` 内部加 `minimumInteractiveComponentSize()`，覆盖其 3 处调用点（TextArea.kt×2、ChatDrawer.kt 昵称编辑）

### E. ChatInput 按钮
- 发送按钮 Box（30dp）、`ActionIconButton` 私有封装（改封装一处覆盖多个调用点）

commit 按 A/B/C/D/E 分组，共 5 个。

## 验收条件 | Acceptance criteria

- [ ] 消息操作条 5 个图标、分支切换 2 个图标触达热区 ≥48dp（视觉尺寸仍为 16dp）
- [ ] 设置模型页/技能页/图生成页/消息工具按钮点击热区恢复 48dp 兜底
- [ ] Select 下拉、Switch 开关、TagList 删除/添加、ChatInput 发送按钮均可正常点击且热区 ≥48dp
- [ ] 上述改动不改变任何视觉尺寸与布局

## UI 截图 / 录屏 | UI evidence

N/A（纯 touch target 热区扩展，视觉零变化，无本地真机环境）

## 测试 | Testing

- 命令 / 检查：grep 全仓 `minimumInteractiveComponentSize` 使用处数 = 16（A 9 + C 4 + D 1 + E 2），与清单一一对应；5 个文件括号配对平衡校验通过；无新增未使用 import
- 结果：未运行编译/构建/测试（无本地 Gradle 环境，已确认仓库 CI 无 lint 强制门禁）；建议合并后按验收条件真机验证

## 数据兼容 | Data compatibility

N/A（纯 UI 修饰符改动，无数据/配置变更）

## 风险与回滚 | Risks and rollback

- 风险：`minimumInteractiveComponentSize` 会扩大布局测量尺寸，紧凑布局（ImgGen 卡片、InputChip、Switch 行）可能出现轻微间距变化；已对紧凑点采用「保留视觉 size + minimum 兜底」避免视觉变化
- 回滚：revert 对应 commit 即可，无数据影响

## 已知限制 | Known limitations

低优先级候选本次未做（信息密集型或文本级，改动收益低/风险高，留待后续评估）：JsonTree 行/ValueText、Tag.kt:58、EmojiItem 40dp、ConversationItem、FolderChip、WorkspaceTerminalPage Tab、AsrButton、ChatMessageAvatar、ProviderConnectionTester/SubagentToolUIs/Markdown 文本级点击。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录：未执行编译/构建/测试（无本地环境），已用 grep 与静态检查验证
- [x] 已检查提交内容不含敏感信息
- [x] 文档/本地化：N/A
- [x] 合并后将任务置为「待验证」
