### PR TITLE
ci(pr-apk): PR 自动触发试装包构建

### DIFF
--- a/.github/workflows/pr-apk.yml
+++ b/.github/workflows/pr-apk.yml
@@ -1,11 +1,15 @@
-# 轻量试装包：对任意分支 / commit 手动出 arm64 prTest APK。
-# 用法：Actions → PR / Branch APK → Run workflow → 可选填 ref（空则用所选 branch）
+# 轻量试装包：PR 到 release/rikka-arsucar 自动出 arm64 prTest APK；也可手动对任意分支 / commit 出包。
+# 自动触发：Actions → PR / Branch APK（PR 事件 opened/synchronize/reopened/ready_for_review）
+# 手动用法：Actions → PR / Branch APK → Run workflow → 可选填 ref（空则用所选 branch）
 # 产物：Artifacts；applicationId = me.arsucar.rikka.pr，不覆盖正式版 me.arsucar.rikka。
 # 不覆盖 nightly、不 bump 版本、不发 Release。
-# 关联：Closes #167
+# 关联：Closes #167；自动触发见 #256
 name: PR / Branch APK
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [release/rikka-arsucar]
   workflow_dispatch:
     inputs:
       ref:
@@ -18,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-apk-${{ github.event.inputs.ref || github.ref }}
+  group: pr-apk-${{ github.event.inputs.ref || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -30,7 +34,7 @@ jobs:
         run: |
           REF="${{ github.event.inputs.ref }}"
           if [ -z "$REF" ]; then
-            REF="${{ github.ref_name }}"
+            REF="${{ github.head_ref || github.ref_name }}"
           fi
           echo "value=$REF" >> "$GITHUB_OUTPUT"
           echo "Building ref: $REF"


### PR DESCRIPTION
## 背景 / 根因

`.github/workflows/pr-apk.yml`（workflow 名 "PR / Branch APK"）之前 `on:` 只有 `workflow_dispatch`，没有任何 `pull_request` 触发器。PR 永远不会自动构建试装包，每次都要人工到 Actions 页面手动 Run workflow 并选择分支，易漏且无状态检查。

## 改动内容

1. **`on:` 增加 `pull_request` 触发器**（保留 `workflow_dispatch` 不动）：
   - `types: [opened, synchronize, reopened, ready_for_review]`
   - `branches: [release/rikka-arsucar]`
2. **Resolve ref 步骤 REF 回退顺序**改为 `inputs.ref` → `github.head_ref` → `github.ref_name`：
   - PR 事件下 `github.head_ref` 是头分支名，自动构建头分支；
   - 手动触发时 `head_ref` 为空回退 `ref_name`，手动行为不变。
3. **concurrency group 加入 `github.head_ref`**：`pr-apk-${{ github.event.inputs.ref || github.head_ref || github.ref }}`，区分 PR 与手动触发；同一 PR 连续 push 自动取消旧构建、保留最新。
4. **头部注释更新**：说明 PR 到 release/rikka-arsucar 自动构建、手动触发仍可用。

signing / 构建 / 上传步骤未动。

## 验证情况

- 本 PR **自身不会触发**该 workflow：GitHub 只用默认分支（release/rikka-arsucar）上的 workflow 文件响应 `pull_request` 事件，合并后才对后续 PR 生效。
- workflow YAML 语法无法本地验证，合并后需在后续 PR 上观察（opened/synchronize 事件应自动出 arm64 prTest APK artifact）。
- **已知限制**：fork 来源的外部 PR 拿不到仓库签名 secrets，会卡在 Prepare signing 步骤（`KEYSTORE_BASE64 secret is missing` 报错退出）。仓库现阶段主要接受内部分支 PR，此限制在 Issue #256 中亦有记录。
- 手动触发（Actions → Run workflow）行为保持与现在一致：`inputs.ref` 优先，空则回退 `ref_name`。

Closes #256