### PR TITLE
fix: close 429 responses before replay

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/AIRequestInterceptor.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/AIRequestInterceptor.kt
@@ -107,11 +107,15 @@ class AIRequestInterceptor(
             return response
         }
 
-        // 当前仍存活的 429 响应（未被 close），供上层读取/分类
-        var lastResponse: Response = response
+        // Only the response returned to OkHttp may remain open. Every response that is
+        // replaced by a replay is closed before the next chain.proceed call. This is
+        // important for OkHttp: proceeding while the previous response body is still
+        // open can fail with "previous response is still open".
+        val responseLifecycle = ReplayResponseLifecycle(response)
         val switches = mutableListOf<SwitchAttempt>()
         var finalCode: Int? = response.code
         var exhausted = false
+
         return try {
             runBlocking {
                 for (attempt in 1..clashConfig.maxRetries) {
@@ -132,36 +136,36 @@ class AIRequestInterceptor(
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
                         switches += SwitchAttempt(nodeName = null, success = false, error = e.message, replayedCode = null)
-                        return@runBlocking lastResponse
+                        return@runBlocking responseLifecycle.handOff()
                     }
                     delay(clashConfig.switchDelayMs) // 挂起式等待，不占 dispatcher 线程
 
+                    // Release the previous response before opening the replay response.
+                    // If proceed throws, the old response is already closed and must not be
+                    // returned to the caller; the exception is allowed to propagate.
+                    responseLifecycle.closeBeforeReplay()
                     val replayed = try {
                         chain.proceed(request) // 重放原请求（不持锁）
                     } catch (io: IOException) {
                         Log.i("ClashRetry", "attempt $attempt proceed IOException: ${io.message}")
                         switches += SwitchAttempt(nodeName = switchedTo, success = true, error = "proceed IOException: ${io.message}", replayedCode = null)
-                        return@runBlocking lastResponse
+                        throw io
                     }
+                    responseLifecycle.accept(replayed)
                     switches += SwitchAttempt(nodeName = switchedTo, success = true, error = null, replayedCode = replayed.code)
+                    finalCode = replayed.code
                     if (replayed.code != 429) {
-                        finalCode = replayed.code
-                        lastResponse.close() // 丢弃旧 429 body，避免连接泄漏
-                        return@runBlocking replayed // 重放成功（AC2）
+                        return@runBlocking responseLifecycle.handOff() // 重放成功（AC2）
                     }
-                    lastResponse.close()
-                    lastResponse = replayed
                     Log.i("ClashRetry", "attempt $attempt still 429, switched to $switchedTo")
                 }
                 exhausted = true // 重试耗尽 -> 最后一次 429 原样返回（AC4）
-                lastResponse
+                responseLifecycle.handOff()
             }
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            Log.i("ClashRetry", "429 retry skipped: ${e.message}")
-            switches += SwitchAttempt(nodeName = null, success = false, error = e.message, replayedCode = null)
-            lastResponse // 任一步失败 -> 原 429（AC3），保持未 close 可读
-        }.also {
+        } finally {
+            // Covers cancellation during the delay/replay and any unexpected exception.
+            // A response handed to OkHttp must remain open for its caller to consume.
+            responseLifecycle.closeIfNotHandedOff()
             runBlocking {
                 clashRetryTracer.record(
                     ClashRetryTrace(
@@ -200,5 +204,32 @@ class AIRequestInterceptor(
         private const val SKIP_MAX_RETRIES = "SKIP_MAX_RETRIES"
         private const val SKIP_NO_PROVIDER = "SKIP_NO_PROVIDER"
         private const val SKIP_ROTATION_DISABLED = "SKIP_ROTATION_DISABLED"
+    }
+}
+
+/** Owns the response currently held by the interceptor during replay. */
+internal class ReplayResponseLifecycle(initial: Response) {
+    private var current: Response? = initial
+    private var handedOff = false
+
+    /** Closes the response before [Interceptor.Chain.proceed] opens its replay response. */
+    fun closeBeforeReplay() {
+        current?.close()
+        current = null
+    }
+
+    fun accept(response: Response) {
+        check(current == null) { "previous response must be closed before accepting replay" }
+        current = response
+    }
+
+    fun handOff(): Response {
+        handedOff = true
+        return checkNotNull(current)
+    }
+
+    /** Closes an owned response on cancellation or an exception before hand-off. */
+    fun closeIfNotHandedOff() {
+        if (!handedOff) current?.close()
     }
 }

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/ReplayResponseLifecycleTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/ReplayResponseLifecycleTest.kt
@@ -1,0 +1,77 @@
+package me.rerere.rikkahub.data.ai
+
+import okhttp3.MediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okio.BufferedSource
+import okio.buffer
+import okio.source
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReplayResponseLifecycleTest {
+    @Test
+    fun `replaced responses close while handed off response stays open`() {
+        val first = trackedResponse(429)
+        val second = trackedResponse(429)
+        val final = trackedResponse(200)
+        val lifecycle = ReplayResponseLifecycle(first.response)
+
+        lifecycle.closeBeforeReplay()
+        lifecycle.accept(second.response)
+        lifecycle.closeBeforeReplay()
+        lifecycle.accept(final.response)
+        lifecycle.handOff()
+        lifecycle.closeIfNotHandedOff()
+
+        assertTrue(first.body.closed)
+        assertTrue(second.body.closed)
+        assertFalse(final.body.closed)
+    }
+
+    @Test
+    fun `owned response closes when replay is cancelled or fails`() {
+        val tracked = trackedResponse(429)
+        val lifecycle = ReplayResponseLifecycle(tracked.response)
+
+        lifecycle.closeIfNotHandedOff()
+
+        assertTrue(tracked.body.closed)
+    }
+
+    @Test
+    fun `final 429 remains open after handoff`() {
+        val tracked = trackedResponse(429)
+        val lifecycle = ReplayResponseLifecycle(tracked.response)
+
+        lifecycle.handOff()
+        lifecycle.closeIfNotHandedOff()
+
+        assertFalse(tracked.body.closed)
+    }
+
+    private fun trackedResponse(code: Int): TrackedResponse {
+        val body = TrackingBody()
+        val response = Response.Builder()
+            .request(Request.Builder().url("http://localhost").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("test")
+            .body(body)
+            .build()
+        return TrackedResponse(response, body)
+    }
+
+    private data class TrackedResponse(val response: Response, val body: TrackingBody)
+
+    private class TrackingBody : ResponseBody() {
+        var closed = false
+        override fun contentType(): MediaType? = null
+        override fun contentLength(): Long = 0
+        override fun source(): BufferedSource = "".source().buffer()
+        override fun close() { closed = true }
+    }
+}


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #239

## 变更说明 | Changes

`AIRequestInterceptor` 在 429 自动切换 Clash 节点并重放请求时，先关闭当前由拦截器持有的响应，再调用 `chain.proceed`，避免 OkHttp 因前一个 response body 仍处于打开状态而拒绝重放。新增 `ReplayResponseLifecycle` 负责区分正在持有、已替换和已交给调用方的响应，确保异常/取消时关闭仍由拦截器拥有的响应，同时保持最终返回的响应可读。

新增 `ReplayResponseLifecycleTest`，覆盖被替换响应关闭、重放取消/失败时清理，以及最终 429 交给调用方后保持打开等生命周期回归场景。

## 验收条件 | Acceptance criteria

- [x] 429 切换重放前关闭上一响应，避免 `previous response is still open`。
- [x] 重放成功时返回新的非 429 响应。
- [x] 重试耗尽时最终 429 响应仍交给上层读取，不被拦截器提前关闭。
- [x] 异常或取消发生在响应仍由拦截器持有时，响应会被关闭。

## UI 截图 / 录屏 | UI evidence

N/A — 无 UI 变更。

## 测试 | Testing

- 命令 / 检查：检查 worktree 状态、目标 commit 内容、相对 `origin/release/rikka-arsucar` 的 diff，以及 `git diff --check`。
- 结果：通过；worktree clean，目标 commit 为 `7f4ab1540b1c71883ec0f5655837942772bb8da9`，仅包含拦截器修复和生命周期回归测试，diff 无 whitespace 错误。
- 命令 / 检查：`./gradlew ...`（Gradle 单元测试/构建）。
- 结果：未运行；当前环境无 Java/JDK，因此无法运行 Gradle。

## 数据兼容 | Data compatibility

N/A — 无数据库、备份、配置格式或 API 数据迁移。

## 风险与回滚 | Risks and rollback

风险集中在 429 重放异常路径的 response 所有权管理；正常非 429 响应路径保持不变。若出现回归，可回滚 commit `7f4ab1540b1c71883ec0f5655837942772bb8da9`。

## 已知限制 | Known limitations

本环境未运行 Gradle 测试或构建，因为无 Java/JDK；新增测试已随 commit 提供，需由 CI 验证。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
