### PR TITLE
fix: stop checkpoint reasoning timer carryover

### DIFF
--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -76,8 +76,10 @@ data class UIMessage(
                             acc
                         } else {
                             val lastPart = acc.lastOrNull()
-                            if (lastPart is UIMessagePart.Reasoning) {
-                                // Append to the last Reasoning part
+                            if (lastPart is UIMessagePart.Reasoning && lastPart.finishedAt == null) {
+                                // Append only to the active reasoning tail. A closed reasoning part
+                                // may be followed by a new generation (for example after restoring
+                                // a checkpoint), so it must not inherit the old start time.
                                 acc.dropLast(1) + UIMessagePart.Reasoning(
                                     reasoning = lastPart.reasoning + deltaPart.reasoning,
                                     createdAt = lastPart.createdAt,
@@ -86,8 +88,8 @@ data class UIMessage(
                                     it.metadata = deltaPart.metadata ?: lastPart.metadata
                                 }
                             } else {
-                                // Create new Reasoning part
-                                acc + deltaPart
+                                // Create a fresh reasoning part for a new generation.
+                                acc + deltaPart.copy(finishedAt = null)
                             }
                         }
                     }

--- a/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
@@ -1,6 +1,7 @@
 package me.rerere.ai.ui
 
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.time.Instant
 import me.rerere.ai.core.MessageRole
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -180,6 +181,88 @@ class MessageTest {
     }
 
     // ==================== isValidToUpload Tests ====================
+
+    @Test
+    fun `new reasoning delta starts a fresh part after a closed reasoning part`() {
+        val createdAt = Instant.parse("2024-01-01T00:00:00Z")
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Reasoning(
+                    reasoning = "restored",
+                    createdAt = createdAt,
+                    finishedAt = createdAt,
+                )
+            )
+        )
+        val chunk = MessageChunk(
+            id = "chunk",
+            model = "model",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(UIMessagePart.Reasoning(reasoning = " resumed ", finishedAt = null)),
+                    ),
+                    message = null,
+                    finishReason = null,
+                )
+            )
+        )
+
+        val result = message + chunk
+        assertEquals(2, result.parts.size)
+        assertEquals(createdAt, (result.parts[0] as UIMessagePart.Reasoning).createdAt)
+        assertEquals(" resumed ", (result.parts[1] as UIMessagePart.Reasoning).reasoning)
+        assertTrue((result.parts[1] as UIMessagePart.Reasoning).finishedAt == null)
+    }
+
+    @Test
+    fun `active reasoning delta continues the current reasoning tail`() {
+        val createdAt = Instant.parse("2024-01-01T00:00:00Z")
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(UIMessagePart.Reasoning("old", createdAt = createdAt, finishedAt = null))
+        )
+        val chunk = MessageChunk(
+            id = "chunk",
+            model = "model",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(role = MessageRole.ASSISTANT, parts = listOf(UIMessagePart.Reasoning(" tail ", finishedAt = null))),
+                    message = null,
+                    finishReason = null,
+                )
+            )
+        )
+
+        val result = message + chunk
+        assertEquals(1, result.parts.size)
+        assertEquals("old tail ", (result.parts.single() as UIMessagePart.Reasoning).reasoning)
+        assertEquals(createdAt, (result.parts.single() as UIMessagePart.Reasoning).createdAt)
+        assertTrue((result.parts.single() as UIMessagePart.Reasoning).finishedAt == null)
+    }
+
+    @Test
+    fun `finishReasoning closes only active reasoning parts`() {
+        val finishedAt = Instant.parse("2024-01-01T00:01:00Z")
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Reasoning(
+                    reasoning = "restored",
+                    createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+                    finishedAt = finishedAt,
+                ),
+                UIMessagePart.Text("answer"),
+            )
+        )
+
+        val result = message.finishReasoning()
+        assertEquals(message, result)
+    }
 
     @Test
     fun `isValidToUpload should be true for non-empty reasoning with empty text`() {

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -193,6 +193,7 @@ import me.rerere.rikkahub.utils.cancelNotification
 import me.rerere.workspace.WorkspaceBindMount
 import java.io.File
 import java.time.Instant
+import kotlin.time.Instant as KotlinInstant
 import java.security.MessageDigest
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
@@ -3597,11 +3598,42 @@ internal fun Conversation.asFinalSnapshot(): Conversation =
 internal fun shouldSkipInitializeOnGenerating(session: ConversationSession): Boolean =
     session.isGenerating
 
+internal fun Conversation.closeCheckpointReasoning(): Conversation = copy(
+    messageNodes = messageNodes.map { node ->
+        node.copy(
+            messages = node.messages.map { message ->
+                message.copy(
+                    parts = message.parts.map { part ->
+                        if (part is UIMessagePart.Reasoning && part.finishedAt == null) {
+                            // Preserve the duration captured by the checkpoint, but never let the
+                            // historical tail run until the current wall clock.
+                            part.copy(
+                                finishedAt = KotlinInstant.fromEpochMilliseconds(updateAt.toEpochMilli())
+                                    .coerceAtLeast(part.createdAt)
+                            )
+                        } else {
+                            part
+                        }
+                    }
+                )
+            }
+        )
+    }
+)
+
 internal fun hydrateConversationFromDb(
     loaded: Conversation,
     session: ConversationSession,
     json: Json,
 ): Conversation {
     if (session.isGenerating) return loaded
-    return loaded.cleanStaleSubagentStreaming(json)
+    val hydrated = loaded.cleanStaleSubagentStreaming(json)
+    return if (hydrated.isCheckpointSnapshot) {
+        // A checkpoint can contain a provider stream that ended between snapshots. Treat its
+        // unfinished reasoning as historical at restore time. The next reasoning delta will then
+        // start a new part (see UIMessage.appendChunk), so only the resumed generation tail runs.
+        hydrated.closeCheckpointReasoning()
+    } else {
+        hydrated
+    }
 }

--- a/app/src/test/java/me/rerere/rikkahub/service/CheckpointCacheTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/service/CheckpointCacheTest.kt
@@ -2,6 +2,11 @@ package me.rerere.rikkahub.service
 
 import me.rerere.rikkahub.data.datastore.DEFAULT_ASSISTANT_ID
 import me.rerere.rikkahub.data.model.Conversation
+import me.rerere.rikkahub.data.model.MessageNode
+import me.rerere.ai.core.MessageRole
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
+import kotlin.time.Instant
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -21,6 +26,38 @@ class CheckpointCacheTest {
         assertFalse(final.isCheckpointSnapshot)
         assertNull(final.checkpointStep)
         assertEquals(conversation.id, final.id)
+    }
+
+    @Test
+    fun `checkpoint restore closes historical reasoning without changing its start`() {
+        val createdAt = Instant.parse("2024-01-01T00:00:00Z")
+        val conversation = Conversation(
+            assistantId = DEFAULT_ASSISTANT_ID,
+            messageNodes = listOf(
+                MessageNode(
+                    messages = listOf(
+                        UIMessage(
+                            role = MessageRole.ASSISTANT,
+                            parts = listOf(
+                                UIMessagePart.Reasoning(
+                                    reasoning = "restored",
+                                    createdAt = createdAt,
+                                    finishedAt = null,
+                                )
+                            ),
+                        )
+                    )
+                )
+            ),
+            isCheckpointSnapshot = true,
+            updateAt = java.time.Instant.parse("2024-01-01T00:05:00Z"),
+        )
+
+        val restored = conversation.closeCheckpointReasoning()
+        val reasoning = restored.messageNodes.single().messages.single().parts.single()
+            as UIMessagePart.Reasoning
+        assertEquals(createdAt, reasoning.createdAt)
+        assertEquals(Instant.parse("2024-01-01T00:05:00Z"), reasoning.finishedAt)
     }
 
     @Test


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #238

## 变更说明 | Changes

Checkpoint-restored assistant messages could retain an unfinished reasoning part from the previous generation, causing the reasoning timer to continue across a resumed generation.

This change:
- Treats checkpoint snapshots as historical when hydrating a non-generating conversation and closes unfinished reasoning parts at the checkpoint update time.
- Preserves the original reasoning start time and prevents finished reasoning tails from receiving later deltas.
- Starts a fresh reasoning part for resumed reasoning deltas.
- Adds regression coverage for checkpoint restoration, active reasoning continuation, and closed reasoning behavior.

## 验收条件 | Acceptance criteria

- [x] Restored checkpoint reasoning no longer accumulates elapsed time through a later generation.
- [x] Active reasoning deltas still append to the current reasoning part.
- [x] Resumed reasoning starts a new part after a closed checkpoint reasoning part.
- [x] Existing navigation/UI behavior is unaffected; this is a service/model behavior fix.

## UI 截图 / 录屏 | UI evidence

N/A — no UI changes.

## 测试 | Testing

- 命令 / 检查：`git diff --check 597b2fa046b739c103b1545d64c3234b9353121b^ 597b2fa046b739c103b1545d64c3234b9353121b`
- 结果：通过。
- 命令 / 检查：commit includes targeted regression tests in `ai/src/test/.../MessageTest.kt` and `app/src/test/.../CheckpointCacheTest.kt`.
- 结果：tests were added but not executed because the local environment has no Java/JDK (`JAVA_HOME` is unset and no `java` executable is available); Gradle was not run.

## 数据兼容 | Data compatibility

N/A — no schema, migration, backup/restore format, or API changes.

## 风险与回滚 | Risks and rollback

The main risk is an edge case in checkpoint hydration timing. Rollback is the single commit `597b2fa046b739c103b1545d64c3234b9353121b` if verification finds a regression.

## 已知限制 | Known limitations

Local Gradle test/build verification was not possible because Java/JDK is unavailable.

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
