### PR TITLE
fix: allow permanently disabling sponsor alerts

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -242,6 +242,7 @@ class SettingsStore(
 
         // 赞助提醒
         val SPONSOR_ALERT_DISMISSED_AT = intPreferencesKey("sponsor_alert_dismissed_at")
+        val SPONSOR_ALERT_DISABLED = booleanPreferencesKey("sponsor_alert_disabled")
 
         val WORKSPACE_FILES_STORAGE = stringPreferencesKey("workspace_files_storage")
 
@@ -401,6 +402,7 @@ class SettingsStore(
                 } ?: BackupReminderConfig(),
                 launchCount = preferences[LAUNCH_COUNT] ?: 0,
                 sponsorAlertDismissedAt = preferences[SPONSOR_ALERT_DISMISSED_AT] ?: 0,
+                sponsorAlertDisabled = preferences[SPONSOR_ALERT_DISABLED] == true,
                 workspaceFilesStorage = preferences[WORKSPACE_FILES_STORAGE]
                     ?.let { runCatching { WorkspaceFilesStorage.valueOf(it) }.getOrNull() }
                     ?: WorkspaceFilesStorage.PRIVATE,
@@ -1186,6 +1188,7 @@ private fun MutablePreferences.writeFullSettings(settings: Settings) {
     this[SettingsStore.LAUNCH_COUNT] = settings.launchCount
     this[SettingsStore.WORKSPACE_FILES_STORAGE] = settings.workspaceFilesStorage.name
     this[SettingsStore.SPONSOR_ALERT_DISMISSED_AT] = settings.sponsorAlertDismissedAt
+    this[SettingsStore.SPONSOR_ALERT_DISABLED] = settings.sponsorAlertDisabled
     // [SemanticMemory Plugin]
     this[SettingsStore.SEMANTIC_MEMORY_CONFIG] = JsonInstant.encodeToString(settings.semanticMemoryConfig)
     this[SettingsStore.CLASH_PROXY_CONFIG] = JsonInstant.encodeToString(settings.clashConfig)
@@ -1497,6 +1500,7 @@ data class Settings(
     val backupReminderConfig: BackupReminderConfig = BackupReminderConfig(),
     val launchCount: Int = 0,
     val sponsorAlertDismissedAt: Int = 0,
+    val sponsorAlertDisabled: Boolean = false,
     val workspaceFilesStorage: WorkspaceFilesStorage = WorkspaceFilesStorage.PRIVATE,
     // [SemanticMemory Plugin]
     val semanticMemoryConfig: me.rerere.rikkahub.data.memory.semantic.SemanticMemoryConfig =

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/debug/DebugPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/debug/DebugPage.kt
@@ -292,6 +292,18 @@ private fun MainPage(vm: DebugVM) {
             }
         }
 
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("sponsorAlertDisabled (current: ${settings.sponsorAlertDisabled})", modifier = Modifier.weight(1f))
+            Button(onClick = {
+                vm.updateSettings(settings.copy(sponsorAlertDisabled = !settings.sponsorAlertDisabled))
+            }) {
+                Text(if (settings.sponsorAlertDisabled) "Enable" else "Disable")
+            }
+        }
+
         var markdown by remember { mutableStateOf("") }
         MarkdownBlock(markdown, modifier = Modifier.fillMaxWidth())
         MathBlock(markdown)

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
@@ -92,7 +92,10 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
     val settings by vm.settings.collectAsStateWithLifecycle()
     val filesManager: FilesManager = koinInject()
 
-    if (settings.launchCount > 100 && (settings.launchCount - settings.sponsorAlertDismissedAt) >= 50) {
+    if (!settings.sponsorAlertDisabled &&
+        settings.launchCount > 100 &&
+        (settings.launchCount - settings.sponsorAlertDismissedAt) >= 50
+    ) {
         AlertDialog(
             onDismissRequest = {
                 vm.updateSettings(settings.copy(sponsorAlertDismissedAt = settings.launchCount))
@@ -109,10 +112,17 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
                 }
             },
             dismissButton = {
-                TextButton(onClick = {
-                    vm.updateSettings(settings.copy(sponsorAlertDismissedAt = settings.launchCount))
-                }) {
-                    Text(stringResource(R.string.setting_page_sponsor_alert_dismiss))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextButton(onClick = {
+                        vm.updateSettings(settings.copy(sponsorAlertDismissedAt = settings.launchCount))
+                    }) {
+                        Text(stringResource(R.string.setting_page_sponsor_alert_dismiss))
+                    }
+                    TextButton(onClick = {
+                        vm.updateSettings(settings.copy(sponsorAlertDisabled = true))
+                    }) {
+                        Text(stringResource(R.string.setting_page_sponsor_alert_disable))
+                    }
                 }
             },
         )

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -826,6 +826,7 @@
   <string name="setting_page_sponsor_alert_confirm">寄付</string>
   <string name="setting_page_sponsor_alert_desc">アプリを100回以上起動しました！気に入っていただけたら、開発者をサポートしていただけると嬉しいです。</string>
   <string name="setting_page_sponsor_alert_dismiss">今はしない</string>
+  <string name="setting_page_sponsor_alert_disable">今後表示しない</string>
   <string name="setting_page_sponsor_alert_title">開発者を支援する</string>
   <string name="setting_page_theme_setting">テーマ</string>
   <string name="setting_page_theme_setting_desc">アプリの配色をカスタマイズ</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -826,6 +826,7 @@
   <string name="setting_page_sponsor_alert_confirm">기부하기</string>
   <string name="setting_page_sponsor_alert_desc">앱을 100번 이상 실행하셨네요! 만족스럽게 사용하고 계시다면 개발자를 후원해 주세요.</string>
   <string name="setting_page_sponsor_alert_dismiss">나중에</string>
+  <string name="setting_page_sponsor_alert_disable">다시 알리지 않기</string>
   <string name="setting_page_sponsor_alert_title">개발자 지원하기</string>
   <string name="setting_page_theme_setting">테마</string>
   <string name="setting_page_theme_setting_desc">앱 색상 구성 사용자 지정</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -826,6 +826,7 @@
   <string name="setting_page_sponsor_alert_confirm">Пожертвовать</string>
   <string name="setting_page_sponsor_alert_desc">Вы запустили приложение более 100 раз! Если вам нравится им пользоваться, пожалуйста, поддержите разработчика.</string>
   <string name="setting_page_sponsor_alert_dismiss">Не сейчас</string>
+  <string name="setting_page_sponsor_alert_disable">Больше не напоминать</string>
   <string name="setting_page_sponsor_alert_title">Поддержать разработчика</string>
   <string name="setting_page_theme_setting">Тема</string>
   <string name="setting_page_theme_setting_desc">Настроить цветовую схему приложения</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -826,6 +826,7 @@
   <string name="setting_page_sponsor_alert_confirm">捐款</string>
   <string name="setting_page_sponsor_alert_desc">您已啟動應用程式超過 100 次！如果您喜歡使用它，請考慮支持開發者。</string>
   <string name="setting_page_sponsor_alert_dismiss">稍後再說</string>
+  <string name="setting_page_sponsor_alert_disable">永久不再提醒</string>
   <string name="setting_page_sponsor_alert_title">支援開發者</string>
   <string name="setting_page_theme_setting">主題</string>
   <string name="setting_page_theme_setting_desc">自訂應用配色方案</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1134,6 +1134,7 @@
   <string name="setting_page_sponsor_alert_confirm">捐赠</string>
   <string name="setting_page_sponsor_alert_desc">您已启动应用超过100次！如果您喜欢使用它，请考虑支持开发者。</string>
   <string name="setting_page_sponsor_alert_dismiss">暂不</string>
+  <string name="setting_page_sponsor_alert_disable">永久不再提醒</string>
   <string name="setting_page_sponsor_alert_title">支持开发者</string>
   <string name="setting_page_theme_setting">主题</string>
   <string name="setting_page_theme_setting_desc">自定义应用配色方案</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1182,6 +1182,7 @@
   <string name="setting_page_sponsor_alert_confirm">Donate</string>
   <string name="setting_page_sponsor_alert_desc">You have launched the app over 100 times! If you enjoy using it, please consider supporting the developer.</string>
   <string name="setting_page_sponsor_alert_dismiss">Not Now</string>
+  <string name="setting_page_sponsor_alert_disable">Never remind me again</string>
   <string name="setting_page_sponsor_alert_title">Support the Developer</string>
   <string name="setting_page_theme_setting">Theme</string>
   <string name="setting_page_theme_setting_desc">Customize app color scheme</string>

--- a/app/src/test/java/me/rerere/rikkahub/data/datastore/SettingsModelAndProviderTagsTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/datastore/SettingsModelAndProviderTagsTest.kt
@@ -10,6 +10,12 @@ import kotlin.uuid.Uuid
 
 class SettingsModelAndProviderTagsTest {
     @Test
+    fun sponsorAlertDisabledDefaultsToFalseAndCanBePersistedInModel() {
+        assertFalse(Settings().sponsorAlertDisabled)
+        assertTrue(Settings().copy(sponsorAlertDisabled = true).sponsorAlertDisabled)
+    }
+
+    @Test
     fun recentChatModelMovesSelectedModelToFrontAndKeepsLimit() {
         val models = List(10) { Uuid.random() }
         val settings = Settings.dummy().copy(recentChatModels = models)


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #232

## 变更说明 | Changes

- 在 `Settings` 中新增持久化的 `sponsorAlertDisabled` 标志，默认值为 `false`，并接入 DataStore 读写。
- Sponsor 提醒弹窗新增「永久不再提醒」操作；选择后后续启动不再触发周期性弹窗。
- 保留「稍后」行为，仅更新当前的提醒周期。
- 在 Debug 页面增加该设置的切换入口，便于验证。
- 为新增设置的默认值与模型持久化状态补充单元测试，并更新日文、韩文、俄文、繁体中文和简体中文资源。

## 验收条件 | Acceptance criteria

- [x] 当 `sponsorAlertDisabled` 为 `true` 时，即使启动次数满足提醒条件，Sponsor 弹窗也不会出现。
- [x] 在 Sponsor 弹窗中选择「永久不再提醒」后，设置会持久化，重启后仍不会再次出现。
- [x] `sponsorAlertDisabled` 默认为 `false`，未选择永久关闭时既有周期性提醒逻辑保持不变。
- [x] 「稍后」操作仍可更新提醒周期，不会永久关闭提醒。

## UI 截图 / 录屏 | UI evidence

N/A（本次未提供截图或录屏；UI 文案和按钮已随提交更新。）

## 测试 | Testing

- 命令 / 检查：核对 worktree 状态、提交内容、提交文件列表及与 `origin/release/rikka-arsucar` 的基线。
- 结果：worktree clean；HEAD 为 `584c0b3172fa0a6096c7f3987e194978094e0b6c`；该提交相对基线为单个提交，检查通过。
- 命令 / 检查：检查提交中的 `SettingsModelAndProviderTagsTest` 新增测试。
- 结果：已提交测试代码，但本地无 Java/JDK，未运行 Gradle 或单元测试。

## 数据兼容 | Data compatibility

新增一个带默认值 `false` 的 DataStore 布尔设置；旧配置读取时自动使用默认值，不需要迁移。无数据库、备份/恢复或 API 兼容性影响。

## 风险与回滚 | Risks and rollback

风险较低，变更仅影响 Sponsor 提醒的显示条件和一个本地设置。若发现问题，可回滚提交 `584c0b3172fa0a6096c7f3987e194978094e0b6c`，恢复原有提醒行为。

## 已知限制 | Known limitations

本地未安装 Java/JDK，因此未执行 Gradle 构建或测试；需由 CI/维护者环境完成编译和测试验证。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [ ] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
