### PR TITLE
feat(settings): add searchable settings destinations

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -24,6 +26,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -31,6 +34,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -41,6 +45,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.input.ImeAction
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.AiMagic
@@ -85,12 +90,53 @@ import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
+private data class SettingSearchEntry(
+    val title: String,
+    val description: String,
+    val keywords: String,
+    val screen: Screen,
+)
+
+private fun SettingSearchEntry.matches(query: String): Boolean {
+    val normalizedQuery = query.trim().lowercase()
+    return normalizedQuery.isNotEmpty() &&
+        listOf(title, description, keywords).joinToString(" ").lowercase().contains(normalizedQuery)
+}
+
+@Composable
+private fun settingSearchEntries(): List<SettingSearchEntry> = listOf(
+    SettingSearchEntry(stringResource(R.string.setting_page_preferences), stringResource(R.string.setting_page_preferences_desc), "preferences settings 设置", Screen.SettingPreferences),
+    SettingSearchEntry(stringResource(R.string.setting_page_assistant), stringResource(R.string.setting_page_assistant_desc), "assistant agent 助手", Screen.Assistant),
+    SettingSearchEntry(stringResource(R.string.setting_page_extensions), stringResource(R.string.setting_page_extensions_desc), "extensions prompt skills 扩展", Screen.Extensions),
+    SettingSearchEntry(stringResource(R.string.setting_page_default_model), stringResource(R.string.setting_page_default_model_desc), "model prompt 模型 提示词", Screen.SettingModels),
+    SettingSearchEntry(stringResource(R.string.setting_page_providers), stringResource(R.string.setting_page_providers_desc), "provider api 服务商", Screen.SettingProvider),
+    SettingSearchEntry(stringResource(R.string.setting_page_search_service), stringResource(R.string.setting_page_search_service_desc), "search web 搜索", Screen.SettingSearch),
+    SettingSearchEntry(stringResource(R.string.setting_page_tts_service), stringResource(R.string.setting_page_tts_service_desc), "speech tts voice 语音", Screen.SettingSpeech),
+    SettingSearchEntry(stringResource(R.string.setting_page_semantic_memory), stringResource(R.string.setting_page_semantic_memory_desc), "semantic memory embedding 语义记忆", Screen.SemanticMemory),
+    SettingSearchEntry(stringResource(R.string.setting_page_experiments), stringResource(R.string.setting_page_experiments_desc), "experiments experimental 实验", Screen.Experiments),
+    SettingSearchEntry(stringResource(R.string.setting_page_mcp), stringResource(R.string.setting_page_mcp_desc), "mcp server", Screen.SettingMcp),
+    SettingSearchEntry(stringResource(R.string.setting_page_web_server), stringResource(R.string.setting_page_web_server_desc), "web server 网络", Screen.SettingWeb),
+    SettingSearchEntry(stringResource(R.string.setting_clash_page_title), stringResource(R.string.setting_clash_page_experimental_desc), "clash proxy network 代理", Screen.SettingClash),
+    SettingSearchEntry(stringResource(R.string.setting_page_conversation_tags), stringResource(R.string.setting_page_conversation_tags_desc), "conversation tags chat 标签", Screen.SettingConversationTags),
+    SettingSearchEntry(stringResource(R.string.setting_page_data_backup), stringResource(R.string.setting_page_data_backup_desc), "backup restore 备份", Screen.Backup),
+    SettingSearchEntry(stringResource(R.string.setting_page_chat_storage), stringResource(R.string.setting_page_data_settings), "files storage chat 文件 存储", Screen.SettingFiles),
+    SettingSearchEntry(stringResource(R.string.setting_page_about), stringResource(R.string.setting_page_about_desc), "about app 关于", Screen.SettingAbout),
+    SettingSearchEntry(stringResource(R.string.setting_page_request_logs), stringResource(R.string.setting_page_request_logs_desc), "logs http requests 日志", Screen.Log),
+    SettingSearchEntry(stringResource(R.string.setting_page_donate), stringResource(R.string.setting_page_donate_desc), "donate sponsor 赞助", Screen.SettingDonate),
+    SettingSearchEntry(stringResource(R.string.setting_page_preferences_theme), stringResource(R.string.setting_page_preferences_theme_desc), "theme color dark mode 主题", Screen.SettingPreferencesTheme),
+    SettingSearchEntry(stringResource(R.string.setting_page_preferences_notification), stringResource(R.string.setting_page_preferences_notification_desc), "notifications alerts 通知", Screen.SettingPreferencesNotification),
+    SettingSearchEntry(stringResource(R.string.setting_page_preferences_general), stringResource(R.string.setting_page_preferences_general_desc), "general interaction scrolling input 通用", Screen.SettingPreferencesGeneral),
+    SettingSearchEntry(stringResource(R.string.setting_page_preferences_ui), stringResource(R.string.setting_page_preferences_ui_desc), "ui display fonts code 界面", Screen.SettingPreferencesUI),
+)
+
 @Composable
 fun SettingPage(vm: SettingVM = koinViewModel()) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val navController = LocalNavController.current
     val settings by vm.settings.collectAsStateWithLifecycle()
     val filesManager: FilesManager = koinInject()
+    var searchQuery by rememberSaveable { mutableStateOf("") }
+    val searchEntries = settingSearchEntries()
 
     if (settings.launchCount > 100 && (settings.launchCount - settings.sponsorAlertDismissedAt) >= 50) {
         AlertDialog(
@@ -139,11 +185,49 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
             contentPadding = innerPadding + PaddingValues(8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            if (settings.isNotConfigured()) {
-                item {
-                    ProviderConfigWarningCard(navController)
-                }
+            item("settingsSearch") {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.setting_page_search_hint)) },
+                    leadingIcon = { Icon(HugeIcons.GlobalSearch, contentDescription = null) },
+                    trailingIcon = {
+                        if (searchQuery.isNotEmpty()) {
+                            TextButton(onClick = { searchQuery = "" }) {
+                                Text(stringResource(R.string.setting_page_search_clear))
+                            }
+                        }
+                    },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                )
             }
+            if (searchQuery.isNotBlank()) {
+                val matches = searchEntries.filter { it.matches(searchQuery) }
+                if (matches.isEmpty()) {
+                    item("settingsSearchEmpty") {
+                        Text(
+                            text = stringResource(R.string.setting_page_search_no_results),
+                            modifier = Modifier.padding(24.dp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                } else {
+                    items(matches, key = { it.screen.toString() }) { entry ->
+                        ListItem(
+                            modifier = Modifier.clickable { navController.navigate(entry.screen) },
+                            headlineContent = { Text(entry.title) },
+                            supportingContent = { Text(entry.description) },
+                        )
+                    }
+                }
+            } else {
+                if (settings.isNotConfigured()) {
+                    item {
+                        ProviderConfigWarningCard(navController)
+                    }
+                }
 
             item("generalSettings") {
                 var colorMode by rememberColorMode()
@@ -399,6 +483,7 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
                         headlineContent = { Text(stringResource(R.string.setting_page_share)) },
                     )
                 }
+            }
             }
         }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1124,6 +1124,9 @@
   <string name="setting_page_search_result_size">结果数量</string>
   <string name="setting_page_search_service">搜索服务</string>
   <string name="setting_page_search_service_desc">设置搜索服务</string>
+  <string name="setting_page_search_hint">搜索设置</string>
+  <string name="setting_page_search_clear">清除</string>
+  <string name="setting_page_search_no_results">未找到相关设置</string>
   <string name="setting_page_search_test">测试搜索</string>
   <string name="setting_page_search_test_query_hint">输入测试查询…</string>
   <string name="setting_page_search_test_run">运行测试</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1172,6 +1172,9 @@
   <string name="setting_page_search_result_size">Result Size</string>
   <string name="setting_page_search_service">Search Service</string>
   <string name="setting_page_search_service_desc">Set up search service</string>
+  <string name="setting_page_search_hint">Search settings</string>
+  <string name="setting_page_search_clear">Clear</string>
+  <string name="setting_page_search_no_results">No settings found</string>
   <string name="setting_page_search_test">Test Search</string>
   <string name="setting_page_search_test_query_hint">Enter test query…</string>
   <string name="setting_page_search_test_run">Run Test</string>


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #234

## 变更说明 | Changes

设置页新增可搜索的设置目的地过滤器，支持用户通过关键词识别并直达 22 个设置子页。搜索输入提供清除操作；无匹配项时显示明确的空结果文案。新增中英文本地化资源。

## 验收条件 | Acceptance criteria

- [x] 在设置页输入关键词可过滤设置目的地列表。
- [x] 选择匹配的设置目的地可直达对应子页。
- [x] 支持清除搜索内容，并在无匹配项时显示空结果提示。
- [x] 搜索相关文案同时提供英文和简体中文资源。

## UI 截图 / 录屏 | UI evidence

N/A — 本次通过 CLI 创建 PR，未生成或附加截图/录屏。

## 测试 | Testing

- 命令 / 检查：`git status --porcelain=v1`
- 结果：通过；worktree clean。
- 命令 / 检查：`git diff --check 837cb3204ae274e654b7d11171f77e7be0ae48dd 866168b0a1265f26953712d900d323b77627da92`
- 结果：通过；未发现 whitespace 错误。
- 命令 / 检查：确认目标 commit `866168b0a1265f26953712d900d323b77627da92` 的父提交为基线 `837cb3204ae274e654b7d11171f77e7be0ae48dd`，且基线为 `origin/release/rikka-arsucar` 的祖先。
- 结果：通过。
- 命令 / 检查：Gradle 构建/测试
- 结果：未运行；当前环境无 Java/JDK，无法运行 Gradle。

## 数据兼容 | Data compatibility

N/A — 仅新增设置页 UI 逻辑与本地化资源，不改变持久化数据格式、数据库或 API。

## 风险与回滚 | Risks and rollback

风险：搜索过滤依赖设置目的地的展示名称/关键词匹配，可能存在个别关键词覆盖不足。回滚：如需回退，可还原本 PR 的单个 commit `866168b0a1265f26953712d900d323b77627da92`。

## 已知限制 | Known limitations

未在本地运行 Gradle 构建或测试，需依赖 CI 验证编译与行为。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新；本次已更新本地化资源
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
