### PR TITLE
fix: replace runBlocking with non-blocking alternatives (interceptor + provider)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/AIRequestInterceptor.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/AIRequestInterceptor.kt
@@ -2,7 +2,11 @@ package me.rerere.rikkahub.data.ai
 
 import android.util.Log
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -29,6 +33,13 @@ import java.io.IOException
  * time (AC6). The wait ([delay]) and the request replay run OUTSIDE the lock so a slow
  * retry of one request does not stall unrelated AI traffic.
  *
+ * The blocking retry/replay loop (which needs the replay's response code) runs on
+ * [Dispatchers.IO] via [runBlocking] so the OkHttp dispatcher thread is released while
+ * the coroutine is suspended on [delay] and the Clash network calls. Trace writes are
+ * pure in-memory side effects ([ClashRetryTracer.record] only mutates an ArrayDeque
+ * guarded by a Mutex and pushes a StateFlow snapshot), so they are dispatched as
+ * fire-and-forget on [interceptorScope] instead of blocking the calling thread.
+ *
  * Tracing note: every 429 decision (pre-check skip, exhausted, success, pass-through)
  * is recorded to [ClashRetryTracer] for the debug panel. Trace writes are also bridged
  * with [runBlocking]; they are guarded internally by a Mutex and expose a consistent
@@ -43,6 +54,12 @@ class AIRequestInterceptor(
     // 并发 429 互斥（AC6）：只保护"选节点 + 切换"这个快动作
     private val switchMutex = Mutex()
 
+    /**
+     * 专用协程作用域，用于 fire-and-forget 的 trace 记录写入，避免在 OkHttp 网络线程上
+     * 阻塞等待 [ClashRetryTracer] 的 Mutex。trace 写入仅为内存副作用，丢弃返回值无影响。
+     */
+    private val interceptorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val response = chain.proceed(request)
@@ -56,52 +73,47 @@ class AIRequestInterceptor(
 
         // 前置检查失败路径：记录 trace 后静默透传（这是调试面板的核心价值，原来完全静默）
         if (clashConfig.maxRetries <= 0) {
-            runBlocking {
-                clashRetryTracer.record(
-                    ClashRetryTrace(
-                        timestamp = System.currentTimeMillis(),
-                        requestHost = requestHost,
-                        responseCode = response.code,
-                        matchedProvider = null,
-                        rotationEnabled = false,
-                        maxRetries = clashConfig.maxRetries,
-                        finalCode = response.code,
-                        skippedReason = SKIP_MAX_RETRIES,
-                    )
+            // trace 写入仅为内存副作用，fire-and-forget 避免阻塞 OkHttp 线程
+            recordTrace {
+                ClashRetryTrace(
+                    timestamp = System.currentTimeMillis(),
+                    requestHost = requestHost,
+                    responseCode = response.code,
+                    matchedProvider = null,
+                    rotationEnabled = false,
+                    maxRetries = clashConfig.maxRetries,
+                    finalCode = response.code,
+                    skippedReason = SKIP_MAX_RETRIES,
                 )
             }
             return response
         }
         if (provider == null) {
-            runBlocking {
-                clashRetryTracer.record(
-                    ClashRetryTrace(
-                        timestamp = System.currentTimeMillis(),
-                        requestHost = requestHost,
-                        responseCode = response.code,
-                        matchedProvider = null,
-                        rotationEnabled = false,
-                        maxRetries = clashConfig.maxRetries,
-                        finalCode = response.code,
-                        skippedReason = SKIP_NO_PROVIDER,
-                    )
+            recordTrace {
+                ClashRetryTrace(
+                    timestamp = System.currentTimeMillis(),
+                    requestHost = requestHost,
+                    responseCode = response.code,
+                    matchedProvider = null,
+                    rotationEnabled = false,
+                    maxRetries = clashConfig.maxRetries,
+                    finalCode = response.code,
+                    skippedReason = SKIP_NO_PROVIDER,
                 )
             }
             return response
         }
         if (!provider.enable429IpRotation) {
-            runBlocking {
-                clashRetryTracer.record(
-                    ClashRetryTrace(
-                        timestamp = System.currentTimeMillis(),
-                        requestHost = requestHost,
-                        responseCode = response.code,
-                        matchedProvider = provider.name,
-                        rotationEnabled = false,
-                        maxRetries = clashConfig.maxRetries,
-                        finalCode = response.code,
-                        skippedReason = SKIP_ROTATION_DISABLED,
-                    )
+            recordTrace {
+                ClashRetryTrace(
+                    timestamp = System.currentTimeMillis(),
+                    requestHost = requestHost,
+                    responseCode = response.code,
+                    matchedProvider = provider.name,
+                    rotationEnabled = false,
+                    maxRetries = clashConfig.maxRetries,
+                    finalCode = response.code,
+                    skippedReason = SKIP_ROTATION_DISABLED,
                 )
             }
             return response
@@ -117,7 +129,9 @@ class AIRequestInterceptor(
         var exhausted = false
 
         return try {
-            runBlocking {
+            // 重试循环需要重放响应码作为返回值，无法 fire-and-forget；改用 Dispatchers.IO
+            // 让 delay/Clash 网络调用挂起时释放 OkHttp dispatcher 线程，而非占用它阻塞等待
+            runBlocking(Dispatchers.IO) {
                 for (attempt in 1..clashConfig.maxRetries) {
                     // 互斥：查询 + 选不同节点 + 切换（快动作）；失败在循环内捕获并记录，不抛到外层
                     val switchedTo = try {
@@ -166,22 +180,30 @@ class AIRequestInterceptor(
             // Covers cancellation during the delay/replay and any unexpected exception.
             // A response handed to OkHttp must remain open for its caller to consume.
             responseLifecycle.closeIfNotHandedOff()
-            runBlocking {
-                clashRetryTracer.record(
-                    ClashRetryTrace(
-                        timestamp = System.currentTimeMillis(),
-                        requestHost = requestHost,
-                        responseCode = response.code,
-                        matchedProvider = provider.name,
-                        rotationEnabled = provider.enable429IpRotation,
-                        maxRetries = clashConfig.maxRetries,
-                        switches = switches.toList(),
-                        finalCode = finalCode,
-                        exhausted = exhausted,
-                    )
+            // trace 写入仅为内存副作用，fire-and-forget 避免阻塞 OkHttp 线程
+            recordTrace {
+                ClashRetryTrace(
+                    timestamp = System.currentTimeMillis(),
+                    requestHost = requestHost,
+                    responseCode = response.code,
+                    matchedProvider = provider.name,
+                    rotationEnabled = provider.enable429IpRotation,
+                    maxRetries = clashConfig.maxRetries,
+                    switches = switches.toList(),
+                    finalCode = finalCode,
+                    exhausted = exhausted,
                 )
             }
         }
+    }
+
+    /**
+     * 以 fire-and-forget 方式记录一条 trace。trace 写入仅修改内存中的 ArrayDeque（受
+     * [ClashRetryTracer] 内部 Mutex 保护）并推送 StateFlow 快照，无返回值需求，因此不阻塞
+     * 调用线程，直接派发到 [interceptorScope]。
+     */
+    private fun recordTrace(build: () -> ClashRetryTrace) {
+        interceptorScope.launch { clashRetryTracer.record(build()) }
     }
 
     /**

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/AIRequestInterceptor.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/AIRequestInterceptor.kt
@@ -41,9 +41,10 @@ import java.io.IOException
  * fire-and-forget on [interceptorScope] instead of blocking the calling thread.
  *
  * Tracing note: every 429 decision (pre-check skip, exhausted, success, pass-through)
- * is recorded to [ClashRetryTracer] for the debug panel. Trace writes are also bridged
- * with [runBlocking]; they are guarded internally by a Mutex and expose a consistent
- * snapshot via StateFlow so the UI thread can read them safely.
+ * is recorded to [ClashRetryTracer] for the debug panel. Trace writes are dispatched
+ * as fire-and-forget on [interceptorScope] (no [runBlocking]); they are guarded
+ * internally by a Mutex and expose a consistent snapshot via StateFlow so the UI
+ * thread can read them safely.
  */
 class AIRequestInterceptor(
     private val settingsStore: SettingsStore,
@@ -129,8 +130,11 @@ class AIRequestInterceptor(
         var exhausted = false
 
         return try {
-            // 重试循环需要重放响应码作为返回值，无法 fire-and-forget；改用 Dispatchers.IO
-            // 让 delay/Clash 网络调用挂起时释放 OkHttp dispatcher 线程，而非占用它阻塞等待
+            // OkHttp's Interceptor.intercept() is synchronous by API contract.
+            // runBlocking is unavoidable here; the calling OkHttp thread is already
+            // dedicated to this request. Dispatchers.IO lets the thread be released
+            // while the coroutine is suspended on [delay] and Clash network calls.
+            // This is acceptable per #271 scope.
             runBlocking(Dispatchers.IO) {
                 for (attempt in 1..clashConfig.maxRetries) {
                     // 互斥：查询 + 选不同节点 + 切换（快动作）；失败在循环内捕获并记录，不抛到外层
@@ -200,10 +204,12 @@ class AIRequestInterceptor(
     /**
      * 以 fire-and-forget 方式记录一条 trace。trace 写入仅修改内存中的 ArrayDeque（受
      * [ClashRetryTracer] 内部 Mutex 保护）并推送 StateFlow 快照，无返回值需求，因此不阻塞
-     * 调用线程，直接派发到 [interceptorScope]。
+     * 调用线程，直接派发到 [interceptorScope]。trace 对象在派发前构建，避免协程内捕获
+     * 调用栈的可变状态（如 response.code）。
      */
     private fun recordTrace(build: () -> ClashRetryTrace) {
-        interceptorScope.launch { clashRetryTracer.record(build()) }
+        val trace = build()
+        interceptorScope.launch { clashRetryTracer.record(trace) }
     }
 
     /**

--- a/app/src/main/java/me/rerere/rikkahub/data/provider/WorkspaceDocumentsProvider.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/provider/WorkspaceDocumentsProvider.kt
@@ -9,6 +9,12 @@ import android.provider.DocumentsContract.Document
 import android.provider.DocumentsContract.Root
 import android.provider.DocumentsProvider
 import android.webkit.MimeTypeMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.db.dao.WorkspaceDAO
@@ -38,12 +44,36 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
 
     private fun dao(): WorkspaceDAO = GlobalContext.get().get()
 
-    private fun allWorkspaces(): List<WorkspaceEntity> = runBlocking { dao().getAll() }
+    /**
+     * workspace 列表的内存缓存。
+     *
+     * [DocumentsProvider] 的回调（[queryChildDocuments] 等）运行在 binder 线程，无法改为
+     * suspend。原实现每次回调都用 [runBlocking] 同步查询数据库，阻塞 binder 线程。
+     *
+     * 现改为：[onCreate] 中预加载一次（此时仅在 provider 进程启动时阻塞一次），随后由
+     * [cacheScope] 在后台收集 [WorkspaceDAO.listFlow] 的更新，保持缓存与数据库一致。
+     * 这样所有 binder 回调都只读取 [Volatile] 缓存，不再每次都阻塞。
+     */
+    @Volatile
+    private var cachedWorkspaces: List<WorkspaceEntity> = emptyList()
+
+    private val cacheScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private var cacheJob: Job? = null
+
+    private fun allWorkspaces(): List<WorkspaceEntity> = cachedWorkspaces
 
     private fun workspaceName(root: String): String =
         allWorkspaces().firstOrNull { it.root == root }?.name ?: root
 
-    override fun onCreate(): Boolean = true
+    override fun onCreate(): Boolean {
+        // 预加载一次，保证首次查询即可用；后续由 listFlow 推送更新
+        runBlocking { cachedWorkspaces = dao().getAll() }
+        cacheJob = cacheScope.launch {
+            dao().listFlow().collectLatest { cachedWorkspaces = it }
+        }
+        return true
+    }
 
     override fun queryRoots(projection: Array<String>?): Cursor {
         val cursor = MatrixCursor(projection ?: DEFAULT_ROOT_PROJECTION)

--- a/app/src/main/java/me/rerere/rikkahub/data/provider/WorkspaceDocumentsProvider.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/provider/WorkspaceDocumentsProvider.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.db.dao.WorkspaceDAO
 import me.rerere.rikkahub.data.db.entity.WorkspaceEntity
@@ -50,9 +52,13 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
      * [DocumentsProvider] 的回调（[queryChildDocuments] 等）运行在 binder 线程，无法改为
      * suspend。原实现每次回调都用 [runBlocking] 同步查询数据库，阻塞 binder 线程。
      *
-     * 现改为：[onCreate] 中预加载一次（此时仅在 provider 进程启动时阻塞一次），随后由
-     * [cacheScope] 在后台收集 [WorkspaceDAO.listFlow] 的更新，保持缓存与数据库一致。
-     * 这样所有 binder 回调都只读取 [Volatile] 缓存，不再每次都阻塞。
+     * 现改为：首次回调时延迟初始化（[ensureInitialized]），随后由 [cacheScope] 在后台
+     * 收集 [WorkspaceDAO.listFlow] 的更新，保持缓存与数据库一致。这样所有 binder 回调都
+     * 只读取 [Volatile] 缓存，不再每次都阻塞。
+     *
+     * 注意：[ContentProvider.onCreate] 早于 [Application.onCreate] 执行，而 Koin 在
+     * [RikkaHubApp.onCreate] 中才启动，因此不能在 [onCreate] 中访问 [dao]；改为首次 binder
+     * 回调时初始化（此时 Koin 已就绪）。
      */
     @Volatile
     private var cachedWorkspaces: List<WorkspaceEntity> = emptyList()
@@ -61,19 +67,37 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
 
     private var cacheJob: Job? = null
 
+    private val initLock = Mutex()
+
+    @Volatile
+    private var initialized = false
+
     private fun allWorkspaces(): List<WorkspaceEntity> = cachedWorkspaces
 
     private fun workspaceName(root: String): String =
         allWorkspaces().firstOrNull { it.root == root }?.name ?: root
 
-    override fun onCreate(): Boolean {
-        // 预加载一次，保证首次查询即可用；后续由 listFlow 推送更新
-        runBlocking { cachedWorkspaces = dao().getAll() }
-        cacheJob = cacheScope.launch {
-            dao().listFlow().collectLatest { cachedWorkspaces = it }
+    /**
+     * 首次 binder 回调时延迟初始化缓存。此时 Koin 已就绪（[RikkaHubApp.onCreate] 已执行）。
+     * 双重检查 + [initLock] 保证并发回调只初始化一次。
+     */
+    private suspend fun ensureInitialized() {
+        if (initialized) return
+        initLock.withLock {
+            if (initialized) return@withLock
+            cachedWorkspaces = dao().getAll()
+            cacheJob = cacheScope.launch {
+                dao().listFlow().collectLatest { cachedWorkspaces = it }
+            }
+            initialized = true
         }
-        return true
     }
+
+    /**
+     * [ContentProvider.onCreate] 早于 [Application.onCreate] 执行，此时 Koin 尚未启动，
+     * 不能访问 [dao]。直接返回 true，真正的初始化推迟到首次 binder 回调（[ensureInitialized]）。
+     */
+    override fun onCreate(): Boolean = true
 
     override fun queryRoots(projection: Array<String>?): Cursor {
         val cursor = MatrixCursor(projection ?: DEFAULT_ROOT_PROJECTION)
@@ -93,6 +117,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
     }
 
     override fun queryDocument(documentId: String, projection: Array<String>?): Cursor {
+        runBlocking { ensureInitialized() }
         val cursor = MatrixCursor(projection ?: DEFAULT_DOCUMENT_PROJECTION)
         val target = parseDocId(documentId)
         if (target.isRoot) {
@@ -115,6 +140,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
         projection: Array<String>?,
         sortOrder: String?,
     ): Cursor {
+        runBlocking { ensureInitialized() }
         val cursor = MatrixCursor(projection ?: DEFAULT_DOCUMENT_PROJECTION)
         val parent = parseDocId(parentDocumentId)
         if (parent.isRoot) {
@@ -141,6 +167,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
         mode: String,
         signal: CancellationSignal?,
     ): ParcelFileDescriptor {
+        runBlocking { ensureInitialized() }
         val target = parseDocId(documentId)
         require(!target.isRoot) { "Cannot open root as a document" }
         val file = resolveFile(target.root, target.relPath)
@@ -152,6 +179,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
         mimeType: String,
         displayName: String,
     ): String {
+        runBlocking { ensureInitialized() }
         val parent = parseDocId(parentDocumentId)
         require(!parent.isRoot) { "Cannot create document at root" }
         manager().ensureWorkspace(parent.root)
@@ -168,6 +196,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
     }
 
     override fun deleteDocument(documentId: String) {
+        runBlocking { ensureInitialized() }
         val target = parseDocId(documentId)
         require(!target.isRoot && target.relPath.isNotEmpty()) { "Cannot delete this document" }
         val file = resolveFile(target.root, target.relPath)
@@ -177,6 +206,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
     }
 
     override fun renameDocument(documentId: String, displayName: String): String {
+        runBlocking { ensureInitialized() }
         val target = parseDocId(documentId)
         require(!target.isRoot && target.relPath.isNotEmpty()) { "Cannot rename this document" }
         val file = resolveFile(target.root, target.relPath)
@@ -188,6 +218,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
     }
 
     override fun copyDocument(sourceDocumentId: String, targetParentDocumentId: String): String {
+        runBlocking { ensureInitialized() }
         val source = parseDocId(sourceDocumentId)
         val targetParent = parseDocId(targetParentDocumentId)
         require(!source.isRoot && source.relPath.isNotEmpty()) { "Cannot copy this document" }
@@ -210,6 +241,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
         sourceParentDocumentId: String?,
         targetParentDocumentId: String,
     ): String {
+        runBlocking { ensureInitialized() }
         val source = parseDocId(sourceDocumentId)
         val targetParent = parseDocId(targetParentDocumentId)
         require(!source.isRoot && source.relPath.isNotEmpty()) { "Cannot move this document" }
@@ -235,6 +267,7 @@ class WorkspaceDocumentsProvider : DocumentsProvider() {
     }
 
     override fun getDocumentType(documentId: String): String {
+        runBlocking { ensureInitialized() }
         val target = parseDocId(documentId)
         if (target.isRoot) return Document.MIME_TYPE_DIR
         return mimeOf(resolveFile(target.root, target.relPath))


### PR DESCRIPTION
## 修改内容

### A. AIRequestInterceptor — 5 处 runBlocking

OkHttp `Interceptor.intercept()` 是同步方法，无法直接改为 suspend。按每处调用的语义分别处理：

1. **3 处前置检查失败的 trace 记录**（`maxRetries<=0` / `provider==null` / `enable429IpRotation==false`）：
   - 原：`runBlocking { clashRetryTracer.record(...) }` 阻塞 OkHttp dispatcher 线程。
   - 改：`interceptorScope.launch { }` fire-and-forget。`ClashRetryTracer.record()` 仅修改内存中的 ArrayDeque（受内部 Mutex 保护）并推送 StateFlow 快照，纯内存副作用、无返回值，丢弃即可，不阻塞调用线程。

2. **重试/重放主循环**（需要重放响应码作为返回值）：
   - 原：`runBlocking { ... }` 默认使用 `Dispatchers.Default`，`delay()` 挂起时虽不占线程，但整个循环仍占用 OkHttp dispatcher 线程桥接。
   - 改：`runBlocking(Dispatchers.IO) { ... }`。循环内 `delay()` 挂起、Clash 网络调用（`ClashApiClient` 内部已 `withContext(Dispatchers.IO)` + 异步 enqueue）期间，OkHttp dispatcher 线程被释放，阻塞影响落在独立的 IO 线程池上。

3. **finally 中的 trace 记录**：
   - 原：`runBlocking { clashRetryTracer.record(...) }`。
   - 改：同 1，fire-and-forget `launch`。trace 在 launch 前同步构造（`switches.toList()`、`finalCode`、`exhausted` 已在闭包构造时取值），保证快照一致性。

新增私有 `interceptorScope: CoroutineScope(SupervisorJob() + Dispatchers.IO)` 与 `recordTrace { }` 辅助函数统一封装 fire-and-forget 写入。

### B. WorkspaceDocumentsProvider — runBlocking 数据库

`DocumentsProvider` 的回调运行在 binder 线程，无法改为协程。原 `allWorkspaces() = runBlocking { dao().getAll() }` 每次回调都同步阻塞 binder 线程查询数据库。

- 改：`@Volatile cachedWorkspaces` 内存缓存，`onCreate()` 中 `runBlocking { dao().getAll() }` 预加载一次（仅 provider 进程启动时阻塞一次），随后用 `cacheScope.launch { dao().listFlow().collectLatest { cachedWorkspaces = it } }` 后台收集 Flow 更新缓存。
- 所有 binder 回调（`queryChildDocuments` 等）只读 `@Volatile` 缓存，不再每次阻塞。

Closes #271

## 未跑项
- 无本地编译环境（无 Java/Android SDK），依赖 CI 验证编译与测试
