### PR TITLE
fix: reduce streaming UI jank (reasoning timer + Markdown debounce)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt
@@ -128,7 +128,7 @@ private fun rememberReasoningState(reasoning: UIMessagePart.Reasoning): Pair<Rea
         if (loading) {
             while (isActive) {
                 state.duration = (reasoning.finishedAt ?: Clock.System.now()) - reasoning.createdAt
-                delay(50)
+                delay(200)
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -84,6 +84,7 @@ import androidx.compose.ui.util.fastForEach
 import androidx.core.net.toUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
@@ -111,6 +112,7 @@ import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 import org.intellij.markdown.parser.MarkdownParser
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
 
 private val flavour by lazy {
     GFMFlavourDescriptor(
@@ -247,6 +249,7 @@ fun MarkdownBlock(
     LaunchedEffect(Unit) {
         snapshotFlow { updatedContent }
             .distinctUntilChanged()
+            .debounce(50.milliseconds)
             .mapLatest { parseMarkdown(it) }
             .catch { exception -> exception.printStackTrace() }
             .flowOn(Dispatchers.Default)

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.util.fastForEach
 import androidx.core.graphics.toColorInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
@@ -83,6 +84,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
+import kotlin.time.Duration.Companion.milliseconds
 
 // ---- Preprocessing (mirrors Markdown.kt logic) ----
 
@@ -137,6 +139,7 @@ fun MarkdownNew(
     LaunchedEffect(Unit) {
         snapshotFlow { updatedContent }
             .distinctUntilChanged()
+            .debounce(50.milliseconds)
             .mapLatest { generateMarkdownHtml(it) }
             .catch { it.printStackTrace() }
             .flowOn(Dispatchers.Default)


### PR DESCRIPTION
## 修改内容

### A. ChatMessageReasoning 计时器降频
- `delay(50)` → `delay(200)`：从 20Hz 降到 5Hz，减少思考块卡片重组频率

### B. Markdown 解析加 debounce
- `Markdown.kt` / `MarkdownNew.kt`：snapshotFlow 加 `.debounce(50.milliseconds)`，减少 40 tps 下的 mapLatest 空转

Closes #269

## 未跑项
- 无本地编译环境，依赖 CI 验证
