### PR TITLE
fix: batch Compose perf (collectAsStateWithLifecycle + items key)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -54,7 +54,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -185,7 +185,7 @@ fun ChatInput(
     }
 
     val asr = LocalASRState.current
-    val asrState by asr.state.collectAsState()
+    val asrState by asr.state.collectAsStateWithLifecycle()
     val hapticFeedback = LocalHapticFeedback.current
     val soundEffectPlayer: SoundEffectPlayer = koinInject()
     LaunchedEffect(Unit) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ExtensionContent.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ExtensionContent.kt
@@ -106,7 +106,7 @@ fun LorebooksContent(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        items(lorebooks) { lorebook ->
+        items(lorebooks, key = { it.id }) { lorebook ->
             ListItem(
                 modifier = Modifier.clickable(enabled = onEdit != null || onManage != null) {
                     if (onEdit != null) onEdit(lorebook) else onManage?.invoke()

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/FilesPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/FilesPicker.kt
@@ -110,7 +110,7 @@ internal fun FilesPicker(
     val provider = settings.getCurrentChatModel(conversation)?.findProvider(providers = settings.providers)
     val navController = LocalNavController.current
     val workspaceRepository: WorkspaceRepository = koinInject()
-    val workspaces by workspaceRepository.listFlow().collectAsStateWithLifecycle(initial = emptyList())
+    val workspaces by workspaceRepository.listFlow().collectAsStateWithLifecycle(initialValue = emptyList())
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/FilesPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/FilesPicker.kt
@@ -33,7 +33,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -110,7 +110,7 @@ internal fun FilesPicker(
     val provider = settings.getCurrentChatModel(conversation)?.findProvider(providers = settings.providers)
     val navController = LocalNavController.current
     val workspaceRepository: WorkspaceRepository = koinInject()
-    val workspaces by workspaceRepository.listFlow().collectAsState(initial = emptyList())
+    val workspaces by workspaceRepository.listFlow().collectAsStateWithLifecycle(initial = emptyList())
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/McpPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/McpPicker.kt
@@ -286,7 +286,7 @@ fun McpPicker(
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        items(servers.fastFilter { it.commonOptions.enable }) { server ->
+        items(servers.fastFilter { it.commonOptions.enable }, key = { it.id }) { server ->
             val status by mcpManager.getStatus(server).collectAsStateWithLifecycle(McpStatus.Idle)
             Card {
                 Row(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -25,7 +25,7 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -129,8 +129,8 @@ fun ColumnScope.ChatMessageActionButtons(
 
         if (message.role == MessageRole.ASSISTANT) {
             val tts = LocalTTSState.current
-            val isSpeaking by tts.isSpeaking.collectAsState()
-            val isAvailable by tts.isAvailable.collectAsState()
+            val isSpeaking by tts.isSpeaking.collectAsStateWithLifecycle()
+            val isAvailable by tts.isAvailable.collectAsStateWithLifecycle()
             Icon(
                 imageVector = if (isSpeaking) HugeIcons.StopCircle else HugeIcons.VolumeHigh,
                 contentDescription = stringResource(R.string.tts),

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -234,7 +234,7 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
                                     }
                                 },
                         ) {
-                            items(images) { image ->
+                            items(images, key = { it.url }) { image ->
                                 ZoomableAsyncImage(
                                     model = image.url,
                                     contentDescription = null,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTranslation.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTranslation.kt
@@ -113,7 +113,7 @@ fun LanguageSelectionDialog(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                items(languages) { language ->
+                items(languages, key = { it.toLanguageTag() }) { language ->
                     Card(
                         onClick = {
                             onLanguageSelected(language)

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/BuiltinToolUIs.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/BuiltinToolUIs.kt
@@ -578,7 +578,7 @@ private fun ScreenTimePreview(content: JsonElement, apps: List<JsonElement>) {
                 }
             }
         }
-        items(apps) { app ->
+        items(apps, key = { it.hashCode() }) { app ->
             val name = app.getStringContent("app_name")
                 ?: app.getStringContent("package") ?: return@items
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -702,7 +702,7 @@ private fun SearchWebPreview(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    items(images) { imageUrl ->
+                    items(images, key = { it.hashCode() }) { imageUrl ->
                         AsyncImage(
                             model = imageUrl,
                             contentDescription = null,
@@ -719,7 +719,7 @@ private fun SearchWebPreview(
         }
 
         if (items.isNotEmpty()) {
-            items(items) { item ->
+            items(items, key = { it.hashCode() }) { item ->
                 val url = item.getStringContent("url") ?: return@items
                 val title = item.getStringContent("title") ?: return@items
                 val text = item.getStringContent("text") ?: return@items
@@ -790,7 +790,7 @@ private fun ScrapeWebPreview(content: JsonElement) {
             )
         }
 
-        items(urls) { url ->
+        items(urls, key = { it.hashCode() }) { url ->
             val urlObject = url.jsonObject
             Column(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TTSController.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/TTSController.kt
@@ -16,7 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,7 +43,7 @@ fun TTSController() {
     val context = LocalContext.current
     val ttsState = LocalTTSState.current
 
-    val isSpeaking by ttsState.isSpeaking.collectAsState()
+    val isSpeaking by ttsState.isSpeaking.collectAsStateWithLifecycle()
     var isVisible by remember { mutableStateOf(false) }
 
     LaunchedEffect(isSpeaking) {
@@ -57,7 +57,7 @@ fun TTSController() {
         tag = "tts_controller",
         visibility = isVisible
     ) {
-        val playbackState by ttsState.playbackState.collectAsState()
+        val playbackState by ttsState.playbackState.collectAsStateWithLifecycle()
         var expand by remember { mutableStateOf(false) }
         Surface(
             shape = CircleShape,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -810,7 +810,7 @@ private fun ChatSuggestionsRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        items(conversation.chatSuggestions) { suggestion ->
+        items(conversation.chatSuggestions, key = { it }) { suggestion ->
             Box(
                 modifier = Modifier
                     .clip(RoundedCornerShape(50))

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchPage.kt
@@ -199,7 +199,7 @@ fun SearchPage(vm: SearchVM = koinViewModel()) {
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                             modifier = Modifier.fillMaxSize(),
                         ) {
-                            items(vm.results) { result ->
+                            items(vm.results, key = { it.hashCode() }) { result ->
                                 SearchResultItem(
                                     result = result,
                                     onClick = {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingClashPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingClashPage.kt
@@ -23,7 +23,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,7 +57,7 @@ fun SettingClashPage() {
     val settings = LocalSettings.current
     val clashConfig = settings.clashConfig
     val clashRetryTracer: ClashRetryTracer = koinInject()
-    val traces by clashRetryTracer.traces.collectAsState()
+    val traces by clashRetryTracer.traces.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val scope = rememberCoroutineScope()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDonatePage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDonatePage.kt
@@ -144,7 +144,7 @@ private fun Sponsors(modifier: Modifier = Modifier) {
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier.fillMaxSize()
             ) {
-                items(value) {
+                items(value, key = { it.userName }) {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
@@ -848,7 +848,7 @@ private fun McpToolsConfigure(
                 Text(stringResource(R.string.setting_mcp_page_tools_unavailable_message))
             }
         }
-        items(config.commonOptions.tools) { tool ->
+        items(config.commonOptions.tools, key = { it.name }) { tool ->
             McpToolCard(
                 tool = tool,
                 onEnableChange = { newVal ->

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
@@ -1042,7 +1042,7 @@ private fun ModelPicker(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(8.dp),
                 ) {
-                    items(filteredModels) {
+                    items(filteredModels, key = { it.modelId }) {
                         Card {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderPage.kt
@@ -223,7 +223,7 @@ fun SettingProviderPage(vm: SettingVM = koinViewModel()) {
                                 label = { Text(stringResource(R.string.filter_all)) }
                             )
                         }
-                        items(allTags) { tag ->
+                        items(allTags, key = { it }) { tag ->
                             FilterChip(
                                 selected = selectedFilterTag == tag,
                                 onClick = { selectedFilterTag = if (selectedFilterTag == tag) null else tag },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
@@ -210,7 +210,7 @@ private fun AddProviderDialog(
             LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                items(SearchServiceOptions.TYPES.keys.toList()) { type ->
+                items(SearchServiceOptions.TYPES.keys.toList(), key = { it }) { type ->
                     val name = SearchServiceOptions.TYPES[type] ?: "Unknown"
                     val isSelected = selectedType == type
                     Card(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSpeechPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSpeechPage.kt
@@ -706,8 +706,8 @@ private fun TTSProviderItem(
 ) {
     var showDropdownMenu by remember { mutableStateOf(false) }
     val tts = LocalTTSState.current
-    val isSpeaking by tts.isSpeaking.collectAsState()
-    val isAvailable by tts.isAvailable.collectAsState()
+    val isSpeaking by tts.isSpeaking.collectAsStateWithLifecycle()
+    val isAvailable by tts.isAvailable.collectAsStateWithLifecycle()
 
     Card(
         modifier = modifier,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/share/handler/ShareHandlerPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/share/handler/ShareHandlerPage.kt
@@ -81,7 +81,7 @@ fun ShareHandlerPage(text: String, image: String?) {
                 }
             }
 
-            items(settings.activeAssistants()) { assistant ->
+            items(settings.activeAssistants(), key = { it.id }) { assistant ->
                 Surface(
                     onClick = {
                         scope.launch {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/webview/WebViewPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/webview/WebViewPage.kt
@@ -171,7 +171,7 @@ fun WebViewPage(url: String, contentId: String) {
 
                 SelectionContainer {
                     LazyColumn {
-                        items(state.consoleMessages) { message ->
+                        items(state.consoleMessages, key = { it.hashCode() }) { message ->
                             Text(
                                 text = "${message.messageLevel().name}: ${message.message()}\n" +
                                     "Source: ${message.sourceId()}:${message.lineNumber()}",


### PR DESCRIPTION
## 修改内容

### A. 8 处 collectAsState → collectAsStateWithLifecycle
涉及 6 个文件：ChatMessageActions.kt（2处）、ChatInput.kt（1处）、TTSController.kt（2处）、SettingSpeechPage.kt（2处）、SettingClashPage.kt（1处）、FilesPicker.kt（1处）

### B. 17 处 items() 添加 key 参数
涉及 14 个文件：ChatMessageTools.kt、BuiltinToolUIs.kt（4处）、ChatMessageTranslation.kt、McpPicker.kt、ExtensionContent.kt、ChatList.kt、SettingProviderDetailPage.kt、SettingProviderPage.kt、SettingMcpPage.kt、SettingDonatePage.kt、SettingSearchPage.kt、SearchPage.kt、WebViewPage.kt、ShareHandlerPage.kt

Closes #272

## 未跑项
- 无本地编译环境，依赖 CI 验证
