### PR TITLE
fix(subagent): prevent reuse of budget-exhausted contexts & reset tool budget on context reuse

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/subagent/SubagentContextCache.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/subagent/SubagentContextCache.kt
@@ -50,6 +50,7 @@ data class SubagentContext(
     val usage: TokenUsage? = null,
     val lastError: String? = null,
     val revision: Long = 0,
+    val contextCompleteness: SubagentContextCompleteness = SubagentContextCompleteness.FULL,
 )
 
 enum class SubagentContextErrorCode {
@@ -177,7 +178,9 @@ class SubagentContextCache(
             .asReversed()
             .asSequence()
             .filter { context ->
-                context.status == SubagentStatus.COMPLETED && context.scope == scope
+                context.status == SubagentStatus.COMPLETED &&
+                    context.scope == scope &&
+                    context.contextCompleteness != SubagentContextCompleteness.BOUNDED_FULL
             }
             .maxWithOrNull(
                 compareBy<SubagentContext>(
@@ -218,6 +221,7 @@ class SubagentContextCache(
         messages: List<UIMessage>? = null,
         usage: TokenUsage? = null,
         error: String? = null,
+        contextCompleteness: SubagentContextCompleteness? = null,
     ): SubagentContext? {
         ensureRestored()
         val finished = mutex.withLock {
@@ -230,6 +234,7 @@ class SubagentContextCache(
             usage = usage ?: existing.usage,
             lastError = error,
             revision = existing.revision + 1,
+            contextCompleteness = contextCompleteness ?: existing.contextCompleteness,
         )
         contexts[contextId] = finished
         pruneExpiredLocked(now)

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/subagent/SubagentContextStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/subagent/SubagentContextStore.kt
@@ -58,6 +58,7 @@ private fun SubagentContext.toEntity() = SubagentContextEntity(
     updatedAtMillis = lastAccessAtMillis,
     expiresAtMillis = expiresAtMillis,
     revision = revision,
+    contextCompleteness = contextCompleteness.name,
 )
 
 private fun SubagentContextEntity.toModel() = SubagentContext(
@@ -71,4 +72,7 @@ private fun SubagentContextEntity.toModel() = SubagentContext(
     usage = usageJson?.let { JsonInstant.decodeFromString<TokenUsage>(it) },
     lastError = lastError,
     revision = revision,
+    contextCompleteness = runCatching {
+        SubagentContextCompleteness.valueOf(contextCompleteness)
+    }.getOrDefault(SubagentContextCompleteness.FULL),
 )

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/subagent/SubagentHost.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/subagent/SubagentHost.kt
@@ -142,6 +142,11 @@ internal suspend fun persistSubagentFailure(
         messages = cached?.messages ?: fallbackMessages,
         usage = cached?.usage ?: fallbackUsage,
         error = error,
+        contextCompleteness = if (fallbackMessages.isEmpty() && cached?.messages.isNullOrEmpty()) {
+            SubagentContextCompleteness.UNAVAILABLE
+        } else {
+            SubagentContextCompleteness.PARTIAL
+        },
     )
 }
 
@@ -534,6 +539,11 @@ class SubagentHost(
                 status = SubagentStatus.COMPLETED,
                 messages = messages,
                 usage = totalUsage,
+                contextCompleteness = if (truncated || generationLimitReached) {
+                    SubagentContextCompleteness.BOUNDED_FULL
+                } else {
+                    SubagentContextCompleteness.FULL
+                },
             )
             logResult(result)
             result
@@ -688,6 +698,9 @@ class SubagentHost(
         var finalMessages = initialMessages
         var truncated = false
         val maxToolCalls = effectiveMaxToolCalls(profile)
+        // #285: 复用 context 时，旧 messages 中的 tool calls 不应计入新任务预算。
+        // 记录基线，budget 检查和 countdown 都减去基线，使新任务获得完整预算。
+        val baselineExecutedToolCalls = countExecutedToolCalls(initialMessages)
         try {
             generationHandler.generateText(
                 settings = settings,
@@ -701,7 +714,7 @@ class SubagentHost(
                 } else {
                     null
                 },
-                stepsCountdownTotal = effectiveMaxToolCalls(profile),
+                stepsCountdownTotal = effectiveMaxToolCalls(profile) + baselineExecutedToolCalls,
                 stepsCountdownLabel = "Tool calls",
                 memories = emptyList(),
                 workspaceCwd = workspaceCwd,
@@ -723,7 +736,7 @@ class SubagentHost(
                     }
                     if (enforceToolBudget &&
                         !profile.disableToolBudgetStop &&
-                        countExecutedToolCalls(finalMessages) >= maxToolCalls
+                        countExecutedToolCalls(finalMessages) - baselineExecutedToolCalls >= maxToolCalls
                     ) {
                         truncated = true
                         throw ToolCallBudgetStop

--- a/app/src/main/java/me/rerere/rikkahub/data/db/AppDatabase.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/AppDatabase.kt
@@ -81,7 +81,7 @@ import me.rerere.rikkahub.utils.JsonInstant
         MemoryTableSnapshotEntity::class,
         SubagentContextEntity::class,
     ],
-    version = 52,
+    version = 53,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -104,6 +104,7 @@ import me.rerere.rikkahub.utils.JsonInstant
         AutoMigration(from = 39, to = 40, spec = Migration_39_40::class),
         AutoMigration(from = 40, to = 41),
         AutoMigration(from = 41, to = 42),
+        AutoMigration(from = 52, to = 53),
     ]
 )
 @TypeConverters(TokenUsageConverter::class)

--- a/app/src/main/java/me/rerere/rikkahub/data/db/dao/SubagentContextDAO.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/dao/SubagentContextDAO.kt
@@ -31,6 +31,7 @@ interface SubagentContextDAO {
             created_at = :createdAtMillis,
             updated_at = :updatedAtMillis,
             expires_at = :expiresAtMillis,
+            context_completeness = :contextCompleteness,
             revision = :revision
         WHERE context_id = :contextId AND revision < :revision
         """
@@ -47,6 +48,7 @@ interface SubagentContextDAO {
         createdAtMillis: Long,
         updatedAtMillis: Long,
         expiresAtMillis: Long,
+        contextCompleteness: String,
         revision: Long,
     ): Int
 
@@ -64,6 +66,7 @@ interface SubagentContextDAO {
             createdAtMillis = entity.createdAtMillis,
             updatedAtMillis = entity.updatedAtMillis,
             expiresAtMillis = entity.expiresAtMillis,
+            contextCompleteness = entity.contextCompleteness,
             revision = entity.revision,
         )
         if (updated == 0) insertIgnore(entity)

--- a/app/src/main/java/me/rerere/rikkahub/data/db/entity/SubagentContextEntity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/entity/SubagentContextEntity.kt
@@ -26,4 +26,5 @@ data class SubagentContextEntity(
     @ColumnInfo(name = "updated_at") val updatedAtMillis: Long,
     @ColumnInfo(name = "expires_at") val expiresAtMillis: Long,
     @ColumnInfo(name = "revision") val revision: Long,
+    @ColumnInfo(name = "context_completeness", defaultValue = "FULL") val contextCompleteness: String = "FULL",
 )


### PR DESCRIPTION
## Summary

Fixes two subagent context budget bugs:

### #284 — `acquireLatestCompleted` reuses budget-exhausted contexts

**Root cause**: `acquireLatestCompleted` filter only checked `status == COMPLETED && scope match`, without checking whether the context ended due to tool budget exhaustion (`BOUNDED_FULL`). `SubagentContext` did not store `contextCompleteness` at all — it only existed in the ephemeral `SubagentResult`.

**Fix**: 
- Added `contextCompleteness: SubagentContextCompleteness` field to `SubagentContext`
- Persisted via new `context_completeness` DB column (AutoMigration 52→53)
- `finish()` now accepts and stores `contextCompleteness`
- `acquireLatestCompleted` filter excludes `BOUNDED_FULL` contexts

### #285 — Reused context's tool calls counted against new task budget

**Root cause**: `runToCompletion` uses `countExecutedToolCalls(finalMessages) >= maxToolCalls` for the budget check, but `finalMessages` includes all messages from the reused context. Old tool calls consume the new task's budget, leaving little to no room for new work.

**Fix**:
- Record `baselineExecutedToolCalls = countExecutedToolCalls(initialMessages)` at entry
- Budget check: `countExecutedToolCalls(finalMessages) - baselineExecutedToolCalls >= maxToolCalls`
- `stepsCountdownTotal`: `effectiveMaxToolCalls(profile) + baselineExecutedToolCalls` so GenerationHandler's countdown also accounts for the baseline

New contexts have `baselineExecutedToolCalls = 0`, so behavior is unchanged for non-reuse scenarios.

## Changed files

- `SubagentContextCache.kt` — SubagentContext field, finish() param, acquireLatestCompleted filter
- `SubagentContextEntity.kt` — new column
- `SubagentContextStore.kt` — toEntity/toModel mapping
- `SubagentContextDAO.kt` — updateIfNewer SQL + upsertIfNewer param
- `SubagentHost.kt` — finish() call sites (#284) + runToCompletion baseline (#285)
- `AppDatabase.kt` — version 53, AutoMigration 52→53

## Test plan

- [ ] CI compile passes
- [ ] Spawn subagent with tool budget → completes normally
- [ ] Spawn subagent that exhausts budget → `contextCompleteness = BOUNDED_FULL` stored
- [ ] Auto-reuse does NOT pick up BOUNDED_FULL context → creates new context instead
- [ ] Explicit reuse (reuseContextId) of a non-exhausted context → new task gets full tool budget (not inherited from old context)
- [ ] DB migration 52→53 succeeds on upgrade

Closes #284, Closes #285