### PR TITLE
fix(ui): correct Modifier order so clickable includes padding

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
@@ -1574,8 +1574,8 @@ private fun MemoryTableTemplatePicker(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(MaterialTheme.shapes.large)
-                .clickable(enabled = !isSaving, onClick = onManageTemplates)
                 .padding(horizontal = 12.dp, vertical = 14.dp)
+                .clickable(enabled = !isSaving, onClick = onManageTemplates)
                 .alpha(if (isSaving) 0.38f else 1f),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -1627,8 +1627,8 @@ private fun MemoryTableTemplateRow(
         modifier = Modifier
             .fillMaxWidth()
             .clip(MaterialTheme.shapes.large)
-            .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 10.dp)
+            .clickable(enabled = enabled, onClick = onClick)
             .alpha(if (enabled) 1f else 0.38f),
         verticalAlignment = Alignment.Top,
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -771,8 +771,8 @@ private fun TagFilterControl(
                     contentDescription = stringResource(R.string.conversation_tag_filter_clear),
                     modifier = Modifier
                         .clip(CircleShape)
-                        .clickable(onClick = onClear)
                         .padding(6.dp)
+                        .clickable(onClick = onClear)
                         .size(16.dp),
                 )
             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/workspace/WorkspaceTerminalPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/workspace/WorkspaceTerminalPage.kt
@@ -303,8 +303,8 @@ private fun TerminalExtraKey(
                 },
                 shape = RoundedCornerShape(6.dp),
             )
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 8.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .clickable(onClick = onClick),
         style = MaterialTheme.typography.labelMedium,
         color = if (selected) {
             MaterialTheme.colorScheme.onPrimary

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsPage.kt
@@ -670,8 +670,8 @@ private fun ApiModelHealthRow(
         modifier = Modifier
             .fillMaxWidth()
             .clip(MaterialTheme.shapes.medium)
-            .clickable(onClick = onClick)
-            .padding(vertical = 8.dp),
+            .padding(vertical = 8.dp)
+            .clickable(onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         Row(


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #289

## 变更说明 | Changes

调换 5 处 Modifier 链中 `.clickable()` 和 `.padding()` 的顺序，使点击区域包含 padding，触摸目标 ≥48dp。

在 Compose 中 modifier 链按从外到内的顺序应用：`.clickable()` 在 `.padding()` 之前时，点击区域被裁剪到 padding 内部的内容区，导致 padding 区域无法响应点击，且难以满足 Material 推荐的 48dp 最小触摸目标。本次将 `.padding(...)` 移到 `.clickable(...)` 之前，使点击区域包含 padding。

修改文件：
- `app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt` — 标签过滤清除按钮
- `app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt` ×2 — 记忆管理操作按钮 / 模板选择行
- `app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/workspace/WorkspaceTerminalPage.kt` — 终端页面额外按键
- `app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsPage.kt` — 统计页面行

改动仅交换相邻的 `.clickable()` 与 `.padding()` 两行的相对顺序，未改动 `.clip`、`.size`、`.alpha`、`.fillMaxWidth` 等其他 modifier，逻辑无变化。

## 验收条件 | Acceptance criteria

- [ ] 上述 5 处 `.padding(...)` 均位于对应 `.clickable(...)` 之前
- [ ] 其余 modifier 顺序保持不变
- [ ] 点击触摸目标包含 padding 区域，满足 ≥48dp 推荐值

## UI 截图 / 录屏 | UI evidence

纯 modifier 顺序调换，视觉外观无变化，N/A。

## 测试 | Testing

- 命令 / 检查：`git diff` 逐处核对 clickable/padding 顺序
- 结果：5 处均已确认 `.padding(...)` 在 `.clickable(...)` 之前，其余 modifier 顺序未变
- 命令 / 检查：本地编译
- 结果：无本地编译环境，依赖 CI 编译验证

## 数据兼容 | Data compatibility

N/A，仅 UI modifier 顺序调整，不涉及数据库/配置/API。

## 风险与回滚 | Risks and rollback

风险低：仅交换相邻 modifier 顺序，行为变化为「点击区域扩大到包含 padding」，符合预期。回滚方式：`git revert` 本次提交。

## 已知限制 | Known limitations

- 无本地编译环境，依赖 CI 编译验证
- 未在真机测试触摸目标（改动为纯 modifier 顺序调换，逻辑无变化）

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
