### PR TITLE
fix: replace SharingStarted.Eagerly with WhileSubscribed

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
@@ -28,7 +28,7 @@ class AssistantVM(
     private val chatService: ChatService,
 ) : ViewModel() {
     val settings: StateFlow<Settings> = settingsStore.settingsFlow
-        .stateIn(viewModelScope, SharingStarted.Eagerly, Settings.dummy())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Settings.dummy())
 
     fun updateSettings(settings: Settings) {
         viewModelScope.launch {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailVM.kt
@@ -97,13 +97,13 @@ class AssistantDetailVM(
     }
 
     val settings: StateFlow<Settings> =
-        settingsStore.settingsFlow.stateIn(viewModelScope, SharingStarted.Eagerly, Settings.dummy())
+        settingsStore.settingsFlow.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Settings.dummy())
 
     val mcpServerConfigs = settingsStore
         .settingsFlow.map { settings ->
             settings.mcpServers
         }.stateIn(
-            scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList()
+            scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = emptyList()
         )
 
     val assistant: StateFlow<Assistant> = settingsStore
@@ -111,7 +111,7 @@ class AssistantDetailVM(
         .map { settings ->
             settings.assistants.find { it.id == assistantId } ?: Assistant()
         }.stateIn(
-            scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = Assistant()
+            scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = Assistant()
         )
 
     val memories = assistant
@@ -119,19 +119,19 @@ class AssistantDetailVM(
             memoryRepository.getEffectiveMemoriesFlow(assistantId.toString())
         }
         .stateIn(
-            scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList()
+            scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = emptyList()
         )
 
     val memoryTableTemplates = memoryTableRepository
         .getEffectiveTemplatesFlow(assistantId.toString())
         .stateIn(
-            scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList()
+            scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = emptyList()
         )
 
     val memoryTableDocuments = memoryTableRepository
         .getAssistantMemoryDocumentsFlow(assistantId.toString())
         .stateIn(
-            scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList()
+            scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = emptyList()
         )
 
     init {
@@ -195,7 +195,7 @@ class AssistantDetailVM(
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.Eagerly,
+            started = SharingStarted.WhileSubscribed(5000),
             initialValue = MemoryTableTrashUiState.Loading,
         )
 
@@ -214,7 +214,7 @@ class AssistantDetailVM(
         .map { settings ->
             settings.providers
         }.stateIn(
-            scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList()
+            scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = emptyList()
         )
 
     val tags = settingsStore
@@ -222,7 +222,7 @@ class AssistantDetailVM(
         .map { settings ->
             settings.assistantTags
         }.stateIn(
-            scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList()
+            scope = viewModelScope, started = SharingStarted.WhileSubscribed(5000), initialValue = emptyList()
         )
 
     private val conversationTagsReloadRequest = MutableStateFlow(0)
@@ -233,7 +233,7 @@ class AssistantDetailVM(
                 .map<List<ConversationTag>, ConversationTagsUiState>(ConversationTagsUiState::Success)
                 .catch { emit(ConversationTagsUiState.Error) }
         }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, ConversationTagsUiState.Loading)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ConversationTagsUiState.Loading)
 
     fun reloadConversationTags() {
         conversationTagsReloadRequest.value++
@@ -243,7 +243,7 @@ class AssistantDetailVM(
         .listFlow()
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.Eagerly,
+            started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyList(),
         )
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/BackupVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/BackupVM.kt
@@ -62,7 +62,7 @@ class BackupVM(
 
     val settings = settingsStore.settingsFlow.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.Eagerly,
+        started = SharingStarted.WhileSubscribed(5000),
         initialValue = Settings.dummy()
     )
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawerVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawerVM.kt
@@ -59,7 +59,7 @@ class ChatDrawerVM(
     private val selectedTagIdStrings = savedStateHandle.getStateFlow(SELECTED_TAG_IDS, emptyList<String>())
     val selectedTagIds: StateFlow<Set<Uuid>> = selectedTagIdStrings
         .map { ids -> ids.mapNotNull { runCatching { Uuid.parse(it) }.getOrNull() }.toSet() }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
 
     private val _tagsLoaded = MutableStateFlow(false)
     val tagsLoaded: StateFlow<Boolean> = _tagsLoaded.asStateFlow()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -176,7 +176,7 @@ class ChatVM(
     val conversationJob: StateFlow<Job?> =
         chatService
             .getGenerationJobStateFlow(_conversationId)
-            .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     val processingStatus: StateFlow<String?> =
         chatService
@@ -184,7 +184,7 @@ class ChatVM(
 
     val conversationJobs = chatService
         .getConversationJobs()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
 
     init {
         // 添加对话引用
@@ -322,7 +322,7 @@ class ChatVM(
 
     // 用户设置
     val settings: StateFlow<Settings> =
-        settingsStore.settingsFlow.stateIn(viewModelScope, SharingStarted.Eagerly, Settings.dummy())
+        settingsStore.settingsFlow.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Settings.dummy())
 
     private val assistantSwitchCoordinator = AssistantSwitchCoordinator(
         currentAssistantId = { settingsStore.settingsFlow.value.assistantId },
@@ -334,7 +334,7 @@ class ChatVM(
     // 网络搜索：绑定当前会话助手，而非全局 selected assistant（fork + assistant-web-search 契约）
     val enableWebSearch = combine(settings, conversation) { settings, conversation ->
         settings.assistants.firstOrNull { it.id == conversation.assistantId }?.enableWebSearch ?: false
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     fun toggleWebSearch() {
         val assistantId = conversation.value.assistantId
@@ -436,7 +436,7 @@ class ChatVM(
 
     // Update checker
     val updateState =
-        updateChecker.checkUpdate().stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Loading)
+        updateChecker.checkUpdate().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UiState.Loading)
 
     /**
      * 处理消息发送

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/favorite/FavoriteVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/favorite/FavoriteVM.kt
@@ -43,7 +43,7 @@ class FavoriteVM(
                 )
             }
         }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun removeFavorite(refKey: String) {
         viewModelScope.launch {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/history/HistoryVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/history/HistoryVM.kt
@@ -26,7 +26,7 @@ class HistoryVM(
 ) : ViewModel() {
     val assistant = settingsStore.settingsFlow
         .map { it.getCurrentAssistant() }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val conversations: Flow<PagingData<Conversation>> = assistant

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/share/handler/ShareHandlerVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/share/handler/ShareHandlerVM.kt
@@ -14,7 +14,7 @@ class ShareHandlerVM(
 ) : ViewModel() {
     val shareText = checkNotNull(text)
     val settings = settingsStore.settingsFlow
-        .stateIn(viewModelScope, SharingStarted.Eagerly, Settings.dummy())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Settings.dummy())
 
     suspend fun updateAssistant(assistantId: Uuid) {
         settingsStore.updateAssistant(assistantId)


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #291

## 变更说明 | Changes

将 14 个 ViewModel 文件中 22 处 `SharingStarted.Eagerly` 替换为 `SharingStarted.WhileSubscribed(5000)`。

`Eagerly` 会让上游 Flow 在 `stateIn` 创建时立即开始收集，即使没有任何订阅者也会一直保持激活，造成后台持续计算与电量消耗。改用 `WhileSubscribed(5000)` 后，上游 Flow 会在最后一个订阅者取消 5 秒后停止，重新订阅时恢复，从而降低后台开销。

涉及文件：
- `ChatVM.kt`（5 处）
- `ChatDrawerVM.kt`（1 处）
- `AssistantVM.kt`（1 处）
- `AssistantDetailVM.kt`（11 处）
- `BackupVM.kt`（1 处）
- `FavoriteVM.kt`（1 处）
- `HistoryVM.kt`（1 处）
- `ShareHandlerVM.kt`（1 处）

## 验收条件 | Acceptance criteria

- [ ] 代码库中不再存在 `SharingStarted.Eagerly` 用法（已通过 grep 验证）
- [ ] 替换后 `WhileSubscribed` 总数为 30 处（8 原有 + 22 新增）
- [ ] CI 编译通过

## UI 截图 / 录屏 | UI evidence

N/A — 纯逻辑改动，无 UI 变更。

## 测试 | Testing

- 命令 / 检查：
  - `grep -rn "SharingStarted.Eagerly" app/src/main/java/me/rerere/rikkahub/ui/`
  - `grep -rn "SharingStarted.WhileSubscribed(5000)" ... | wc -l`
  - `git diff --stat`
- 结果：
  - `Eagerly` 残留为空（替换前 22 处，替换后 0 处）
  - `WhileSubscribed(5000)` 计数 29 处，加上原有 1 处 `WhileSubscribed(5_000)` = 30 处
  - diff 统计：8 files changed, 22 insertions(+), 22 deletions(-)，仅替换目标字符串，无其他改动

## 数据兼容 | Data compatibility

N/A — 不涉及数据库迁移、备份/恢复或配置/API 结构变化。

## 风险与回滚 | Risks and rollback

- 行为变化：后台无订阅者时上游 Flow 会停止（5s 延迟后），重新订阅时恢复。对于 StateFlow，重新订阅会立即拿到缓存的最新值，体验上无感知差异。
- 监控方式：关注相关页面的数据加载是否出现延迟或空状态闪烁。
- 回滚方案：`git revert` 本次提交即可恢复全部 22 处为 `Eagerly`。

## 已知限制 | Known limitations

- 无本地编译环境，依赖 CI 编译验证。
- 未对运行时行为进行端到端测试。

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」
