### PR TITLE
feat(#302): 优化酒馆角色卡导入，支持世界书绑定 + 弹窗确认

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/export/ExportSerializer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/export/ExportSerializer.kt
@@ -374,6 +374,100 @@ private data class SillyTavernEntry(
 )
 
 /**
+ * 角色卡 V2/V3 `data.character_book` 内嵌世界书（见 issue #302）。
+ *
+ * 字段命名遵循角色卡规范（malfoyslastname/character-card-spec-v2），与独立世界书
+ * [SillyTavernLorebook] 的字段名不同（`keys` vs `key`、`enabled` vs `disable`、
+ * `insertion_order` vs `order`、`position` 是 string vs int），故单独定义。
+ *
+ * 不支持的 spec 字段（`selective` / `secondary_keys` / `recursive_scanning` /
+ * `scan_depth` / `token_budget`）忽略但不破坏——依赖 DefaultJson.ignoreUnknownKeys。
+ */
+@Serializable
+private data class CharacterBook(
+    val name: String? = null,
+    val description: String? = null,
+    val entries: List<CharacterBookEntry> = emptyList(),
+)
+
+@Serializable
+private data class CharacterBookEntry(
+    val keys: List<String> = emptyList(),
+    val content: String = "",
+    val extensions: Map<String, JsonElement> = emptyMap(),
+    val enabled: Boolean = true,
+    val insertionOrder: Int = 100,
+    val caseSensitive: Boolean? = null,
+    val name: String? = null,
+    val priority: Int? = null,
+    val id: Int? = null,
+    val comment: String? = null,
+    val selective: Boolean? = null,
+    val secondaryKeys: List<String>? = null,
+    val constant: Boolean = false,
+    val position: String? = null,
+)
+
+/**
+ * 解析角色卡 V2/V3 `data.character_book` 内嵌世界书为 [Lorebook]（见 issue #302）。
+ *
+ * Context-free 纯函数，便于 JVM 单测。`characterBookJson` 为 null、解码失败或 entries 为空时返回 null。
+ * position 字符串映射沿用 [LorebookSerializer.mapSillyTavernPosition] 的语义但独立实现
+ *（角色卡用 `'before_char'`/`'after_char'`，独立世界书用 int 0-4）。
+ */
+internal fun tryImportCharacterBook(
+    characterBookJson: JsonElement?,
+    fallbackName: String,
+): Lorebook? {
+    if (characterBookJson == null) return null
+    val characterBook = runCatching {
+        ExportSerializer.DefaultJson.decodeFromJsonElement(CharacterBook.serializer(), characterBookJson)
+    }.getOrNull() ?: return null
+    if (characterBook.entries.isEmpty()) return null
+    val entries = characterBook.entries.map { entry ->
+        PromptInjection.RegexInjection(
+            id = Uuid.random(),
+            name = entry.comment?.takeIf { it.isNotBlank() }
+                ?: entry.name?.takeIf { it.isNotBlank() }
+                ?: entry.keys.firstOrNull().orEmpty(),
+            enabled = entry.enabled,
+            priority = entry.insertionOrder,
+            position = mapCharacterBookPosition(entry.position),
+            injectDepth = 4,
+            content = entry.content,
+            keywords = entry.keys,
+            useRegex = false,
+            caseSensitive = entry.caseSensitive ?: false,
+            scanDepth = 4,
+            constantActive = entry.constant,
+        )
+    }
+    return Lorebook(
+        id = Uuid.random(),
+        name = characterBook.name?.takeIf { it.isNotBlank() }
+            ?: fallbackName,
+        description = characterBook.description.orEmpty(),
+        enabled = true,
+        entries = entries,
+    )
+}
+
+/**
+ * 角色卡 character_book entry 的 position 字符串映射。
+ *
+ * 角色卡规范定义 `position: 'before_char' | 'after_char'`：
+ * - `before_char` → 角色定义之前 → BEFORE_SYSTEM_PROMPT
+ * - `after_char` → 角色定义之后 → AFTER_SYSTEM_PROMPT
+ * - 缺失/未知 → AFTER_SYSTEM_PROMPT（最常用默认）
+ */
+private fun mapCharacterBookPosition(position: String?): InjectionPosition =
+    when (position) {
+        "before_char" -> InjectionPosition.BEFORE_SYSTEM_PROMPT
+        "after_char" -> InjectionPosition.AFTER_SYSTEM_PROMPT
+        else -> InjectionPosition.AFTER_SYSTEM_PROMPT
+    }
+
+/**
  * SillyTavern「提示词预设」（Chat Completion Preset）顶层结构。
  *
  * 只声明本次需要的字段：`prompts` 提供条目内容，`promptOrder` 提供顺序与启用状态，

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
@@ -417,9 +417,16 @@ private fun AssistantCreationSheet(
                     }
 
                     AssistantImporter(
-                        onUpdate = {
-                            update(it)
-                            state.confirm()
+                        onUpdate = { importedAssistant, lorebooks ->
+                            if (lorebooks.isEmpty()) {
+                                // 无附加绑定：走 EditState 原路径
+                                update(importedAssistant)
+                                state.confirm()
+                            } else {
+                                // 有附加世界书：一次性原子写入 lorebooks + assistant，然后关闭弹窗
+                                vm.addAssistantWithLorebooks(importedAssistant, lorebooks)
+                                state.dismiss()
+                            }
                         },
                         modifier = Modifier.fillMaxWidth(),
                     )

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
@@ -281,7 +281,7 @@ fun AssistantPage(vm: AssistantVM = koinViewModel()) {
         }
     }
 
-    AssistantCreationSheet(createState)
+    AssistantCreationSheet(createState, vm)
 
     // 操作菜单 Bottom Sheet
     actionSheetAssistant?.let { assistant ->
@@ -376,6 +376,7 @@ private fun AssistantTagsFilterRow(
 @Composable
 private fun AssistantCreationSheet(
     state: EditState<Assistant>,
+    vm: AssistantVM,
 ) {
     state.EditStateContent { assistant, update ->
         ModalBottomSheet(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
@@ -14,6 +14,7 @@ import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.Avatar
+import me.rerere.rikkahub.data.model.Lorebook
 import me.rerere.rikkahub.data.repository.ConversationRepository
 import me.rerere.rikkahub.data.repository.MemoryRepository
 import me.rerere.rikkahub.data.repository.MemoryTableRepository
@@ -48,6 +49,30 @@ class AssistantVM(
             settingsStore.update(
                 settings.copy(
                     assistants = settings.assistants.plus(assistant.copy(isArchived = false))
+                )
+            )
+        }
+    }
+
+    /**
+     * 添加助手并同时写入关联的世界书（issue #302）。
+     *
+     * 一次性原子写入 lorebooks + assistant，避免分步写入产生的中间状态。
+     * assistant.lorebookIds 自动关联到新建的 lorebook ids。
+     */
+    fun addAssistantWithLorebooks(assistant: Assistant, lorebooks: List<Lorebook>) {
+        viewModelScope.launch {
+            val settings = settings.value
+            val lorebookIds = lorebooks.map { it.id }.toSet()
+            settingsStore.update(
+                settings.copy(
+                    assistants = settings.assistants.plus(
+                        assistant.copy(
+                            isArchived = false,
+                            lorebookIds = lorebookIds,
+                        )
+                    ),
+                    lorebooks = settings.lorebooks.plus(lorebooks)
                 )
             )
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
@@ -7,12 +7,18 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SplitButtonLayout
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,10 +28,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.dokar.sonner.ToastType
+import com.dokar.sonner.ToasterState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -35,33 +42,40 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.ui.UIMessage
-import me.rerere.rikkahub.data.model.Assistant
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.data.export.tryImportCharacterBook
 import me.rerere.rikkahub.data.files.FilesManager
+import me.rerere.rikkahub.data.model.Assistant
+import me.rerere.rikkahub.data.model.Lorebook
 import me.rerere.rikkahub.ui.components.ui.AutoAIIcon
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.utils.ImageUtils
 import me.rerere.rikkahub.utils.jsonPrimitiveOrNull
-import me.rerere.rikkahub.R
 import org.koin.compose.koinInject
-import com.dokar.sonner.ToasterState
+
+/**
+ * 角色卡导入结果：助手 + 检测到的附加世界书
+ */
+data class TavernCardImportResult(
+    val assistant: Assistant,
+    val lorebooks: List<Lorebook>,
+)
 
 @Composable
 fun AssistantImporter(
     modifier: Modifier = Modifier,
-    onUpdate: (Assistant) -> Unit,
+    onUpdate: (Assistant, List<Lorebook>) -> Unit,
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    SillyTavernImporter(
         modifier = modifier,
-    ) {
-        SillyTavernImporter(onImport = onUpdate)
-    }
+        onImport = onUpdate,
+    )
 }
 
 @Composable
-private fun SillyTavernImporter(
-    onImport: (Assistant) -> Unit
+fun SillyTavernImporter(
+    modifier: Modifier = Modifier,
+    onImport: (Assistant, List<Lorebook>) -> Unit,
 ) {
     val context = LocalContext.current
     val filesManager: FilesManager = koinInject()
@@ -69,60 +83,45 @@ private fun SillyTavernImporter(
     val toaster = LocalToaster.current
     var isLoading by remember { mutableStateOf(false) }
 
-    val jsonPickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument()
-    ) { uri ->
-        uri?.let {
-            isLoading = true
-            scope.launch {
-                try {
-                    runCatching {
-                        importAssistantFromUri(
-                            context = context,
-                            uri = uri,
-                            onImport = onImport,
-                            toaster = toaster,
-                            filesManager = filesManager,
-                        )
-                    }.onFailure { exception ->
-                        exception.printStackTrace()
-                        toaster.show(exception.message ?: context.getString(R.string.assistant_importer_import_failed))
+    // 待确认的导入结果（含附加绑定），非 null 时触发弹窗
+    var pendingResult by remember { mutableStateOf<TavernCardImportResult?>(null) }
+
+    val launchImport: (Uri) -> Unit = { uri ->
+        isLoading = true
+        scope.launch {
+            try {
+                val result = importAssistantFromUri(
+                    context = context,
+                    uri = uri,
+                    toaster = toaster,
+                    filesManager = filesManager,
+                )
+                result?.let { importResult ->
+                    if (importResult.lorebooks.isEmpty()) {
+                        // 无附加绑定：直接导入
+                        onImport(importResult.assistant, emptyList())
+                    } else {
+                        // 有附加绑定：弹窗让用户确认
+                        pendingResult = importResult
                     }
-                } finally {
-                    isLoading = false
                 }
+            } finally {
+                isLoading = false
             }
         }
     }
+
+    val jsonPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri -> uri?.let(launchImport) }
 
     val pngPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
-    ) { uri ->
-        uri?.let {
-            isLoading = true
-            scope.launch {
-                try {
-                    runCatching {
-                        importAssistantFromUri(
-                            context = context,
-                            uri = uri,
-                            onImport = onImport,
-                            toaster = toaster,
-                            filesManager = filesManager,
-                        )
-                    }.onFailure { exception ->
-                        exception.printStackTrace()
-                        toaster.show(exception.message ?: context.getString(R.string.assistant_importer_import_failed))
-                    }
-                } finally {
-                    isLoading = false
-                }
-            }
-        }
-    }
+    ) { uri -> uri?.let(launchImport) }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier,
     ) {
         OutlinedButton(
             onClick = {
@@ -130,7 +129,14 @@ private fun SillyTavernImporter(
             },
             enabled = !isLoading
         ) {
-            AutoAIIcon(name = "tavern", modifier = Modifier.padding(end = 8.dp))
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                AutoAIIcon(name = "tavern", modifier = Modifier.padding(end = 8.dp))
+            }
             Text(text = if (isLoading) stringResource(R.string.assistant_importer_importing) else stringResource(R.string.assistant_importer_import_tavern_png))
         }
 
@@ -140,10 +146,93 @@ private fun SillyTavernImporter(
             },
             enabled = !isLoading
         ) {
-            AutoAIIcon(name = "tavern", modifier = Modifier.padding(end = 8.dp))
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                AutoAIIcon(name = "tavern", modifier = Modifier.padding(end = 8.dp))
+            }
             Text(text = if (isLoading) stringResource(R.string.assistant_importer_importing) else stringResource(R.string.assistant_importer_import_tavern_json))
         }
     }
+
+    // 附加绑定确认弹窗
+    pendingResult?.let { result ->
+        BindingConfirmDialog(
+            lorebooks = result.lorebooks,
+            onConfirm = {
+                onImport(result.assistant, result.lorebooks)
+                pendingResult = null
+            },
+            onSkip = {
+                onImport(result.assistant, emptyList())
+                pendingResult = null
+            },
+            onDismiss = {
+                pendingResult = null
+            },
+        )
+    }
+}
+
+/**
+ * 附加绑定确认弹窗：列出检测到的世界书，让用户选择是否导入。
+ *
+ * 长内容可滚动（遵循 ui-131/ui-204 的 heightIn+verticalScroll 规范）。
+ */
+@Composable
+private fun BindingConfirmDialog(
+    lorebooks: List<Lorebook>,
+    onConfirm: () -> Unit,
+    onSkip: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.assistant_importer_binding_dialog_title))
+        },
+        text = {
+            Column(
+                modifier = Modifier.heightIn(max = 400.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(stringResource(R.string.assistant_importer_binding_dialog_message))
+                HorizontalDivider()
+                lorebooks.forEach { lorebook ->
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                lorebook.name.ifEmpty { stringResource(R.string.assistant_importer_unnamed_lorebook) },
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        supportingContent = {
+                            Text(
+                                stringResource(
+                                    R.string.assistant_importer_lorebook_entries_count,
+                                    lorebook.entries.size
+                                )
+                            )
+                        },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.assistant_importer_binding_dialog_import))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onSkip) {
+                Text(stringResource(R.string.assistant_importer_binding_dialog_skip))
+            }
+        },
+    )
 }
 
 // region Parsing Strategy
@@ -246,16 +335,36 @@ private fun parseAssistantFromJson(
     return parser.parse(context = context, json = json, background = background)
 }
 
+/**
+ * 从角色卡 JSON 中提取内嵌世界书（character_book）。
+ *
+ * V2/V3 角色卡的 `data.character_book` 是一个完整的世界书对象，遵循
+ * malfoyslastname/character-card-spec-v2 的 CharacterBook 类型定义。
+ * 注意字段名与独立世界书 JSON 不同（keys vs key、enabled vs disable 等），
+ * 故使用 [tryImportCharacterBook] 而非 [LorebookSerializer.tryImportSillyTavern]。
+ */
+private fun extractLorebooksFromCard(
+    json: JsonObject,
+    cardName: String,
+): List<Lorebook> {
+    val data = json["data"]?.jsonObject ?: return emptyList()
+    val characterBookJson = data["character_book"] ?: return emptyList()
+    val lorebook = tryImportCharacterBook(
+        characterBookJson = characterBookJson,
+        fallbackName = cardName,
+    )
+    return if (lorebook != null) listOf(lorebook) else emptyList()
+}
+
 // endregion
 
 private suspend fun importAssistantFromUri(
     context: Context,
     uri: Uri,
-    onImport: (Assistant) -> Unit,
     toaster: ToasterState,
     filesManager: FilesManager,
-) {
-    try {
+): TavernCardImportResult? {
+    return try {
         val mime = withContext(Dispatchers.IO) { filesManager.getFileMimeType(uri) }
         val (jsonString, backgroundStr) = withContext(Dispatchers.IO) {
             when (mime) {
@@ -280,12 +389,20 @@ private suspend fun importAssistantFromUri(
         }
         val json = Json.parseToJsonElement(jsonString).jsonObject
         val assistant = parseAssistantFromJson(context = context, json = json, background = backgroundStr)
-        onImport(assistant)
+
+        // 提取内嵌世界书（character_book）
+        val lorebooks = extractLorebooksFromCard(
+            json = json,
+            cardName = assistant.name,
+        )
+
+        TavernCardImportResult(assistant = assistant, lorebooks = lorebooks)
     } catch (exception: Exception) {
         exception.printStackTrace()
         toaster.show(
             message = exception.message ?: context.getString(R.string.assistant_importer_import_failed),
             type = ToastType.Error
         )
+        null
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
@@ -14,8 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -25,7 +24,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -196,29 +194,31 @@ private fun BindingConfirmDialog(
         },
         text = {
             Column(
-                modifier = Modifier.heightIn(max = 400.dp).verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .heightIn(max = 400.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 Text(stringResource(R.string.assistant_importer_binding_dialog_message))
-                HorizontalDivider()
                 lorebooks.forEach { lorebook ->
-                    ListItem(
-                        headlineContent = {
-                            Text(
-                                lorebook.name.ifEmpty { stringResource(R.string.assistant_importer_unnamed_lorebook) },
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        },
-                        supportingContent = {
-                            Text(
-                                stringResource(
-                                    R.string.assistant_importer_lorebook_entries_count,
-                                    lorebook.entries.size
-                                )
-                            )
-                        },
-                    )
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text(
+                            text = lorebook.name.ifEmpty {
+                                stringResource(R.string.assistant_importer_unnamed_lorebook)
+                            },
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.assistant_importer_lorebook_entries_count,
+                                lorebook.entries.size,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             }
         },

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -217,6 +217,12 @@
   <string name="assistant_importer_read_json_failed">读取JSON失败</string>
   <string name="assistant_importer_unsupported_file_type">不支持的文件类型: %s</string>
   <string name="assistant_importer_unsupported_spec">不支持的规格: %s</string>
+  <string name="assistant_importer_binding_dialog_title">检测到附加内容</string>
+  <string name="assistant_importer_binding_dialog_message">这个角色卡包含附加世界书，是否一并导入？</string>
+  <string name="assistant_importer_binding_dialog_import">全部导入</string>
+  <string name="assistant_importer_binding_dialog_skip">跳过</string>
+  <string name="assistant_importer_unnamed_lorebook">未命名世界书</string>
+  <string name="assistant_importer_lorebook_entries_count">%1$d 个条目</string>
   <string name="assistant_page_actions">操作</string>
   <string name="assistant_page_add">添加</string>
   <string name="assistant_page_add_body">添加 Body</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,12 @@
   <string name="assistant_importer_read_json_failed">Failed to read JSON</string>
   <string name="assistant_importer_unsupported_file_type">Unsupported file type: %s</string>
   <string name="assistant_importer_unsupported_spec">Unsupported spec: %s</string>
+  <string name="assistant_importer_binding_dialog_title">Additional content detected</string>
+  <string name="assistant_importer_binding_dialog_message">This character card contains additional lorebooks. Import them?</string>
+  <string name="assistant_importer_binding_dialog_import">Import all</string>
+  <string name="assistant_importer_binding_dialog_skip">Skip</string>
+  <string name="assistant_importer_unnamed_lorebook">Unnamed Lorebook</string>
+  <string name="assistant_importer_lorebook_entries_count">%1$d entries</string>
   <string name="assistant_page_actions">Actions</string>
   <string name="assistant_page_add">Add</string>
   <string name="assistant_page_add_body">Add Body</string>


### PR DESCRIPTION
## 概述

实现 #302：优化酒馆角色卡导入，支持角色卡内嵌的 `character_book`（世界书）附加绑定，并在检测到绑定时弹窗让用户确认是否导入。

## 变更内容

### 1. ExportSerializer.kt — 角色卡 character_book 映射

- 新增 `tryImportCharacterBook(characterBookJson: JsonElement?, fallbackName: String): Lorebook?` 顶层函数
- 新增 `CharacterBook` / `CharacterBookEntry` private data class（遵循 [character-card-spec-v2](https://github.com/malfoyslastname/character-card-spec-v2) 的 `CharacterBook` 类型）
- 新增 `mapCharacterBookPosition(position: String?)` 映射（角色卡用 `'before_char'`/`'after_char'` 字符串，与独立世界书的 int 0-4 不同，故独立实现）

**注意**：角色卡内嵌 `character_book` 的字段名与独立世界书 JSON **不同**：
| 角色卡 character_book | 独立世界书 JSON |
|---|---|
| `keys` | `key` |
| `enabled` | `disable`（反义） |
| `insertion_order` | `order` |
| `position: String` | `position: Int` |
| `constant` | `constant` |

因此不能复用 `LorebookSerializer.tryImportSillyTavern`，而是单独实现映射。

### 2. AssistantImporter.kt — 解析 + 弹窗确认

- `importAssistantFromUri` 返回 `TavernCardImportResult(assistant, lorebooks)`
- 新增 `extractLorebooksFromCard()` 从 `data.character_book` 提取世界书
- 检测到附加绑定时弹出 `BindingConfirmDialog`（AlertDialog），列出世界书名称和条目数，提供「全部导入」/「跳过」选项
- 无附加绑定时直接导入（行为与现状一致）
- `onUpdate` 回调签名改为 `(Assistant, List<Lorebook>) -> Unit`
- 弹窗内容可滚动（遵循 ui-131/ui-204 的 `heightIn + verticalScroll` 规范）

### 3. AssistantPage.kt — 回调适配

- `AssistantImporter.onUpdate` 适配新签名
- 有 lorebooks 时调用 `vm.addAssistantWithLorebooks`，无 lorebooks 时走 EditState 原路径

### 4. AssistantVM.kt — 原子写入

- 新增 `addAssistantWithLorebooks(assistant, lorebooks)` 方法
- 一次性原子写入 `lorebooks` + `assistant`（含 `lorebookIds` 绑定），避免分步写入的中间状态

### 5. strings.xml — 本地化

新增词条（中英文）：
- `assistant_importer_binding_dialog_title` / 检测到附加内容
- `assistant_importer_binding_dialog_message` / 这个角色卡包含附加世界书，是否一并导入？
- `assistant_importer_binding_dialog_import` / 全部导入
- `assistant_importer_binding_dialog_skip` / 跳过
- `assistant_importer_unnamed_lorebook` / 未命名世界书
- `assistant_importer_lorebook_entries_count` / %1$d 个条目

## 验收条件对照

- [x] AC1：导入含世界书绑定的角色卡时弹窗提示
- [x] AC2：弹窗可选择导入或跳过
- [x] AC3：确认导入后世界书落盘并关联到新助手（`lorebookIds`）
- [x] AC4：跳过时仅导入角色卡本体
- [x] AC5：无附加绑定的角色卡导入行为与现状一致（不弹窗）
- [x] AC6：PNG 与 JSON 两种导入路径行为一致
- [ ] AC7：绑定格式不合法时不崩溃（runCatching 容错）— 待 CI 验证
- [ ] AC8：单元测试 — **未添加**（无本地编译环境，待后续补充）

## 未完成 / 待后续

- **单元测试**：`tryImportCharacterBook` 的单测（V2/V3 character_book 解析、空字段、坏数据）尚未添加，需在有编译环境后补充
- **CI 编译验证**：本地无 Java/Gradle 环境，依赖 CI 验证编译

## 关联 Issue

Closes #302
