### PR TITLE
fix: 聊天建议去重 + 渲染侧 key 索引化兜底，阻断重复建议行崩溃 (#305)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -2390,6 +2390,7 @@ class ChatService(
             val suggestions =
                 result.message.toText().split("\n").map { it.trim() }
                     .filter { it.isNotBlank() }
+                    .distinct()
                     .take(10)
 
             // Patch suggestions on live session only — never reload full DB object.

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -42,7 +42,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -811,7 +810,7 @@ private fun ChatSuggestionsRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        items(conversation.chatSuggestions, key = { it }) { suggestion ->
+        itemsIndexed(conversation.chatSuggestions, key = { i, it -> "$i-$it" }) { _, suggestion ->
             Box(
                 modifier = Modifier
                     .clip(RoundedCornerShape(50))


### PR DESCRIPTION
## 关联任务 | Linked issue

Closes #305

## 变更说明 | Changes

聊天页底部「AI 建议」行崩溃：`IllegalArgumentException: Key "c" was already used`。模型生成的 `chatSuggestions` 是自由文本，下方拼接的同一行/相邻行可能内容完全相同，而 `ChatList.kt` 的 `items(..., key = { it })` 直接以建议文本作为 Lazy key，无唯一性保证；两行相同即 key 冲突。

双侧修复，其余行为保持不变，共 2 files changed, 2 insertions(+), 2 deletions(-)：

- 数据侧 `ChatService.generateSuggestion`：组装链在 `.take(10)` 之前按序插入 `.distinct()` 去重：
  `result.message.toText().split("\\n").map { it.trim() }.filter { it.isNotBlank() }.distinct().take(10)`
  保证写入会话的 suggestions 本身不含重复项，顺序不变。
- 渲染侧 `ChatList.kt ChatSuggestionsRow`：`items(list, key = { it })` 改为 `itemsIndexed(list, key = { i, it -> "$i-$it" })`，以「索引+文本」生成唯一 key 作为渲染侧兜底，即使上游数据再出现重复也不会触发 Lazy key 冲突崩溃；该文件中仅本次分页这一处使用 `items`，同步移除不再使用的 `androidx.compose.foundation.lazy.items` import（`itemsIndexed` import 原已存在，文件内其他两处 `itemsIndexed` 调用不受影响）。

## 验收条件 | Acceptance criteria

- [ ] CI 构建/检查通过
- [ ] 模型输出包含完全相同的多条建议时，聊天页「AI 建议」行不再崩溃（修复前复现：`IllegalArgumentException: Key ... was already used`）

## UI 截图 / 录屏 | UI evidence

N/A（无 UI 视觉变更，仅为数据去重与 key 索引化修复）

## 测试 | Testing

- 命令 / 检查：本地无 Java/Gradle/Android SDK 环境，未本地编译，依赖 CI 验证。已做静态自检：`git diff` 确认仅改动两个文件、两处逻辑（数据侧 +`.distinct()`；渲染侧 `itemsIndexed` + 索引 key），diff 最小。
- 结果：CI 已验证 —— 「PR / Branch APK」（实际 Kotlin 编译打包，run 33974555356）✅ 成功，可视为对本次两处改动的编译验证；「Static Analysis」（run 33974555368）❌ 失败，但为仓库既有 detekt 配置问题（detekt.yml 引用了当前 detekt 版本不存在/拼写错误的规则属性，在配置校验阶段即失败，未产出任何针对本改动的 finding；该 workflow 在 release/rikka-arsucar 及其他分支上自 2026-08-12 起历次同样失败，与本 PR 无关）；「Add issues and pull requests to roadmap」（run 33974555294）✅ 成功。
- 后续计划：1) CI 构建已通过；2) 功能复现验证：用小模型输出两行/两段完全相同的建议，验证「AI 建议」行正常渲染、重复项被去除且不再崩溃（修复前复现 `IllegalArgumentException: Key ... was already used`）；3) 混合场景（部分重复+部分唯一）滚动与点击回调 `onClickSuggestion(suggestion)` 行为不变；4) 仓库 detekt 配置修复建议另立 issue 跟进。

## 数据兼容 | Data compatibility

N/A（无数据库迁移/API 变更；旧会话中已存在的重复 suggestions 也可正常渲染，不再崩溃）

## 风险与回滚 | Risks and rollback

- 风险低：数据侧仅一次按序去重，渲染侧仅 key 计算方式变化，不改变建议内容与其他列表行为。
- 监控：合并后关注崩溃上报中 `Key .* was already used` 相关 issue 是否归零。
- 回滚方案：revert 该 commit 即可完全恢复原行为。

## 已知限制 | Known limitations

N/A

## 提交前检查 | Pre-flight checklist

- [x] 已如实记录适用的自动化测试、静态检查、构建或未执行/无法验证的项目及结果
- [x] 已检查日志、截图、测试数据和提交内容，不含 Token、密钥、Cookie、个人数据或其他敏感信息
- [x] 文档、变更日志和本地化资源已按需更新，或确认 N/A
- [x] 合并后会将任务置为「待验证」；验收条件验证通过后再置为「已完成」

